### PR TITLE
Ensure that the OS endpoint only returns the opensource product names

### DIFF
--- a/clients/omnitruck/filters.go
+++ b/clients/omnitruck/filters.go
@@ -13,6 +13,19 @@ func FilterList[T comparable](s []T, filter func(T) bool) []T {
 	return out[:counter]
 }
 
+func SelectList[T comparable](s []T, filter func(T) bool) []T {
+	out := make([]T, len(s))
+
+	counter := 0
+	for i := 0; i < len(s); i++ {
+		if filter(s[i]) {
+			out[counter] = s[i]
+			counter++
+		}
+	}
+	return out[:counter]
+}
+
 func FilterProductList[T comparable](s []T, product string, filter func(string, T) bool) []T {
 	out := make([]T, len(s))
 

--- a/clients/omnitruck/product.go
+++ b/clients/omnitruck/product.go
@@ -70,8 +70,8 @@ func SupportedVersion(product string) string {
 }
 
 func EolProductName(name string) bool {
-	_, ok := supportedProducts[name]
-	return !ok
+	p, ok := supportedProducts[name]
+	return !ok || p.SupportedVersion == nil
 }
 
 func EolProductVersion(product string, v ProductVersion) bool {

--- a/services/main.go
+++ b/services/main.go
@@ -49,6 +49,13 @@ func (server *ApiService) productsHandler(c *fiber.Ctx) error {
 	var data omnitruck.ItemList
 	request := server.Omnitruck.Products(params, &data)
 
+	if server.Mode == Opensource {
+		server.Log.Info("filtering opensource products")
+		data = omnitruck.SelectList(data, omnitruck.OsProductName)
+
+		server.Log.Infof("%+v", data)
+	}
+
 	if params.Eol != "true" {
 		data = omnitruck.FilterList(data, omnitruck.EolProductName)
 	}


### PR DESCRIPTION
The /products endpoint was only filtering EOL products and not the Opensource product names as well. This will add a select filter to pull only those.