### PR TITLE
Opensource mode shouldn't filter by EOL version

### DIFF
--- a/services/main.go
+++ b/services/main.go
@@ -52,8 +52,6 @@ func (server *ApiService) productsHandler(c *fiber.Ctx) error {
 	if server.Mode == Opensource {
 		server.Log.Info("filtering opensource products")
 		data = omnitruck.SelectList(data, omnitruck.OsProductName)
-
-		server.Log.Infof("%+v", data)
 	} else if params.Eol != "true" {
 		server.Log.Info("filtering eol products")
 		data = omnitruck.FilterList(data, omnitruck.EolProductName)

--- a/services/main.go
+++ b/services/main.go
@@ -54,9 +54,8 @@ func (server *ApiService) productsHandler(c *fiber.Ctx) error {
 		data = omnitruck.SelectList(data, omnitruck.OsProductName)
 
 		server.Log.Infof("%+v", data)
-	}
-
-	if params.Eol != "true" {
+	} else if params.Eol != "true" {
+		server.Log.Info("filtering eol products")
 		data = omnitruck.FilterList(data, omnitruck.EolProductName)
 	}
 


### PR DESCRIPTION
When we are running in OS mode we only need to filter if the product is Opensource or not and not it's EOL status.