### PR TITLE
Metadata endpoint now maps url to the download endpoint

### DIFF
--- a/clients/omnitruck/omnitruck.go
+++ b/clients/omnitruck/omnitruck.go
@@ -44,11 +44,21 @@ type RequestParams struct {
 
 func (rp *RequestParams) UrlParams() url.Values {
 	v := url.Values{}
-	v.Add("v", rp.Version)
-	v.Add("p", rp.Platform)
-	v.Add("pv", rp.PlatformVersion)
-	v.Add("m", rp.Architecture)
-	v.Add("eol", rp.Eol)
+	if len(rp.Version) > 0 {
+		v.Add("v", rp.Version)
+	}
+	if len(rp.Platform) > 0 {
+		v.Add("p", rp.Platform)
+	}
+	if len(rp.PlatformVersion) > 0 {
+		v.Add("pv", rp.PlatformVersion)
+	}
+	if len(rp.Architecture) > 0 {
+		v.Add("m", rp.Architecture)
+	}
+	if len(rp.Eol) > 0 {
+		v.Add("eol", rp.Eol)
+	}
 
 	return v
 }

--- a/clients/omnitruck/omnitruck.go
+++ b/clients/omnitruck/omnitruck.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"time"
 
 	"github.com/chef/omnitruck-service/clients"
@@ -39,6 +40,17 @@ type RequestParams struct {
 	PlatformVersion string
 	Architecture    string
 	Eol             string
+}
+
+func (rp *RequestParams) UrlParams() url.Values {
+	v := url.Values{}
+	v.Add("v", rp.Version)
+	v.Add("p", rp.Platform)
+	v.Add("pv", rp.PlatformVersion)
+	v.Add("m", rp.Architecture)
+	v.Add("eol", rp.Eol)
+
+	return v
 }
 
 func New(log *log.Entry) Omnitruck {

--- a/services/services.go
+++ b/services/services.go
@@ -104,33 +104,11 @@ func (server *ApiService) Initialize(c Config) *ApiService {
 		server.Log.Info("Adding EOL Validator")
 		eolversion := omnitruck.EolVersionValidator{}
 		server.Validator.Add(&eolversion)
-
-		server.App.Use(license.New(license.Config{
-			Required: c.Mode == Commercial,
-			Next: func(license_id string, c *fiber.Ctx) bool {
-				switch c.Path() {
-				case "/status":
-					return true
-				case "/":
-					return true
-				}
-
-				return false
-			},
-		}))
-	} else {
-		// Add the middleware so it can inject the license locals into the fiber context
-		server.App.Use(license.New(license.Config{
-			Required: c.Mode == Commercial,
-			Next: func(license_id string, c *fiber.Ctx) bool {
-				return true
-			},
-		}))
 	}
 
 	server.App.Use(license.New(license.Config{
 		Required: c.Mode == Commercial,
-		Next: func(license_id string, c *fiber.Ctx) bool {
+		Next: func(c *fiber.Ctx) bool {
 			switch c.Path() {
 			case "/status":
 				return true


### PR DESCRIPTION
The metadata endpoint will now replace the URL it gets from upstream with a link to its own download endpoint. 

This also required changing the license_id field from a header field to a query param field in order to handle passing on the current request license_id