### PR TITLE
Add terraform configuration for Fastly CDN

### DIFF
--- a/.expeditor/config.yml
+++ b/.expeditor/config.yml
@@ -12,6 +12,8 @@ pipelines:
   - verify
   - docker/build:
       definition: .expeditor/build.docker.yml
+  - terraform/cdn:
+      definition: .expeditor/terraform-cdn.pipeline.yml
 
 github:
   # This deletes the GitHub PR branch after successfully merged into the release branch

--- a/.expeditor/terraform-cdn.pipeline.yml
+++ b/.expeditor/terraform-cdn.pipeline.yml
@@ -1,0 +1,30 @@
+---
+FASTLY_API_KEY:
+  path: secret/fastly/data/omnitruck-service
+  field: token
+AWS_ACCESS_KEY_ID:
+  account: aws/chef-telemetry
+  field: token
+
+steps:
+  - label: ':terraform: init & plan'
+    command: |
+      cd terraform/cdn
+
+      # debug
+      env
+      ls -lR
+      pwd
+      terraform version
+
+      terraform init -migrate-state -force-copy -input=false
+      terraform plan -out="$(terraform workspace show).tfplan" -input=false
+
+  - block: ":rocket: Release!"
+
+  - label: ':terraform: apply'
+    command: |
+      cd terraform/cdn
+      # debug
+      echo terraform apply "$(terraform workspace show).tfplan" -input=false
+      ls -lR

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Order is important. The last matching pattern has the most precedence.
 
-*                 @chef/YOUR_TEAM
 .expeditor/**     @chef/jex-team
 README.md         @chef/docs-team
+/terraform/cdn/   @chef/eso-releng

--- a/terraform/cdn/.gitignore
+++ b/terraform/cdn/.gitignore
@@ -1,0 +1,2 @@
+.terraform
+.env

--- a/terraform/cdn/.terraform.lock.hcl
+++ b/terraform/cdn/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/fastly/fastly" {
+  version     = "4.2.0"
+  constraints = ">= 4.2.0"
+  hashes = [
+    "h1:Xo2PWSTlK01OrIJo+Md0Ip/OiMn14Mu93whD9hdAunc=",
+    "zh:07dbd231a15dfd194dff5e82d58f96c61cb149c2a6c93e3e15b129886fc57536",
+    "zh:31146a77bb929f2cd8bfcc5530ab5f586941da5b8f722ad4553562d106103f9e",
+    "zh:434248b104a3e330beec7578e8eea14adcb106de21cb595cff51473911e638b7",
+    "zh:5350bc58ada345967d7863f8fe606b4e2c9ad275390c2d42d9862257c5788185",
+    "zh:60f062b26d0189e2491594084f89da0fb77836eeb307123bfe23e508d790f1a8",
+    "zh:6a85c69e300fc9de05e7c5a58220c4875e092d4bb3f40e6a1ef8f58ff4c53fc7",
+    "zh:8f616ba9f6f82c96f4b70e58d76ac0091ccaac3d7b418b93fca3fe0cc82c9966",
+    "zh:9d26948ba244891bf6ebecbe61ad4b1ad6c5d84fc3702d38f731b3dfa01abb3e",
+    "zh:a3c47ef66a0b6e2a0cbbe4ecb1644f13519445d57786f3560b4a82dd1ca5497b",
+    "zh:b8220960b0b35bd4de484050f2298281f8747eb2446518264436eaeff6f0182e",
+    "zh:c555814e95828cc539a0ba3c2380fe4fe466c9a6630b5ec73c538db0cd026ecc",
+    "zh:e4fbd1e2170f01932acfcb35aec6280cac40249b2e84def3d978a8868bc0fff5",
+    "zh:e5468bb9a7da220fa5766903d99e0026d7cec2b8321a4a8963753e55cbf6ce7e",
+    "zh:eed6f96a57574170ba2a652001fbc038a04d3a6231d9fb4272a4333b46fdb198",
+  ]
+}

--- a/terraform/cdn/README.md
+++ b/terraform/cdn/README.md
@@ -1,0 +1,42 @@
+# cdn
+
+This directory defines the terraform configuration for the omnitruck service's Fastly CDN frontend. 
+
+See Local Setup for how this can be deployed from a local system. See also `.expeditor/terraform-cdn.pipeline.yml` which is a test to see how this terraform configuration could be deployed via buildkite pipelines.
+
+## Local Setup
+
+Install the required terraform version identified in `main.tf`. Consider using [tfenv](https://github.com/tfutils/tfenv) for this purpose, which can manage terraform versions for multiple environments at once (similar to rbenv/pyenv/virtualenv etc) by running `tfenv install` or `tfenv install min-requested`.
+
+Log in to AWS:
+
+```bash
+# Log in and select the chef-telemetry AWS account, configuring it as the AWS profile named chef-telemetry:
+saml2aws login --profile chef-telemetry --force
+export AWS_DEFAULT_PROFILE=chef-telemetry
+export AWS_ACCESS_KEY_ID="$(aws --profile chef-telemetry configure get aws_access_key_id)"
+```
+
+Get a fastly api and put it into an env var. This can be acquired from account settings in the fastly webui, or by getting the existing api key in vault at `secret/fastly/data/omnitruck-service` (note: the api key in vault is explicitly limited to managing the three fastly service ids identified below):
+
+```bash
+export FASTLY_API_KEY="<your-api-key>"
+# -- OR --
+export FASTLY_API_KEY="$(vault read --field=data --format=json 'secret/fastly/data/omnitruck-service' | jq -r .token)"
+```
+
+## Usage
+
+```bash
+terraform init
+terraform plan # just view expected changes
+
+# If deploying for the first time, import the specific fastly service ids that the token is allowed to manage:
+terraform import 'fastly_service_vcl.omnitruck-service-cdn["chefdownload-trial.chef.io"]' '2TbsWof5nga4BDQrr2QUx2'
+terraform import 'fastly_service_vcl.omnitruck-service-cdn["chefdownload-community.chef.io"]' 'TI6lSOqWRDU7as2vUCT101'
+terraform import 'fastly_service_vcl.omnitruck-service-cdn["chefdownload-commerical.chef.io"]' 'P7mCOa11pnY0Qv0RhBScf6'
+
+# Deploy by saving the plan in a file then applying it
+terraform plan -out=default.tfplan
+terraform apply default.tfplan
+```

--- a/terraform/cdn/cdn.tf
+++ b/terraform/cdn/cdn.tf
@@ -1,0 +1,48 @@
+locals {
+  services = [
+    {
+      domain    = "chefdownload-trial.chef.io"
+      origin    = "trial-production.downloads.chef.co"
+      fastly_id = "2TbsWof5nga4BDQrr2QUx2"
+    },
+    {
+      domain    = "chefdownload-community.chef.io"
+      origin    = "opensource-production.downloads.chef.co"
+      fastly_id = "TI6lSOqWRDU7as2vUCT101"
+    },
+    {
+      domain    = "chefdownload-commerical.chef.io"
+      origin    = "commercial-production.downloads.chef.co"
+      fastly_id = "P7mCOa11pnY0Qv0RhBScf6"
+    }
+  ]
+}
+
+resource "fastly_service_vcl" "omnitruck-service-cdn" {
+  for_each = { for s in local.services : s.domain => s }
+
+  name = each.value.domain
+
+  domain {
+    name = each.value.domain
+  }
+
+  backend {
+    name              = "Origin"
+    address           = each.value.origin
+    ssl_cert_hostname = each.value.origin
+    ssl_sni_hostname  = each.value.origin
+    use_ssl           = true
+    port              = 443
+  }
+
+  healthcheck {
+    name              = "Status"
+    method            = "GET"
+    host              = each.value.origin
+    path              = "/status"
+    expected_response = 200
+
+    check_interval = 60000
+  }
+}

--- a/terraform/cdn/main.tf
+++ b/terraform/cdn/main.tf
@@ -1,0 +1,23 @@
+terraform {
+  required_providers {
+    fastly = {
+      source  = "fastly/fastly"
+      version = ">= 4.2.0"
+    }
+  }
+
+  # Requires AWS_ACCESS_KEY_ID environment variable
+  backend "s3" {
+    bucket  = "chef-telemetry-terraform-state"
+    key     = "omnitruck-service/cdn.tfstate"
+    region  = "us-west-2"
+    # use aws' built-in at-rest encryption
+    encrypt = true
+    # TODO: consider kms_key_id field or AWS_SSE_CUSTOMER_KEY env var to
+    # more deliberately manage state file encryption.
+  }
+}
+
+# Requires FASTLY_API_KEY environment variable
+provider "fastly" {
+}


### PR DESCRIPTION
This adds the terraform definitions that were used to configure the Fastly CDN that proxies to the omnitruck-service origin servers.

It also adds a pipeline to test a way to deploy terraform via buildkite pipelines. Based on the current definition of the pipeline it will not apply any changes to infrastructure, only plan them. Depending on if this works as expected and if there is agreement to pursue this strategy further, I will open another PR to either remove the pipeline or allow the pipeline to perform the apply.

## Related Issue
https://chefio.atlassian.net/browse/CHEF-928

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Infrastructure definitions.

## Checklist:
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin]

