### PR TITLE
Fixed supermarket bug filtering out apha version

### DIFF
--- a/clients/omnitruck/product.go
+++ b/clients/omnitruck/product.go
@@ -110,5 +110,5 @@ func OsProductVersion(name string, v ProductVersion) bool {
 	}
 
 	v1, _ := version.NewVersion(string(v))
-	return p.OpensourceVersion.Check(v1)
+	return p.OpensourceVersion.Check(v1.Core())
 }


### PR DESCRIPTION
There was a bug which was filtering out alpa release version from all versions list for open source/community users.

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x ] I have read the **CONTRIBUTING** document.
- [ x] I have run the pre-merge tests locally and they pass.
- [ x] I have updated the documentation accordingly.
- [ x] I have added tests to cover my changes.
- [ x] All new and existing tests passed.
- [x ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
