### PR TITLE
Adding the check for json file at the end of Download url

### DIFF
--- a/services/helpers.go
+++ b/services/helpers.go
@@ -2,9 +2,12 @@ package services
 
 import (
 	"net/url"
+	"strings"
 
 	"github.com/chef/omnitruck-service/clients/omnitruck"
 )
+
+const substring = ".metadata.json"
 
 func buildEndpointUrl(baseUrl string, endpoint string, params *omnitruck.RequestParams) *url.URL {
 	u, _ := url.Parse(baseUrl)
@@ -30,4 +33,24 @@ func getRequestParams(c omnitruck.FiberContext) *omnitruck.RequestParams {
 		LicenseId:       c.Query("license_id"),
 		Eol:             c.Query("eol", "false"),
 	}
+}
+
+func verifyRequestType(params *omnitruck.RequestParams) bool {
+	if strings.Contains(params.Architecture, substring) {
+		params.Architecture = strings.Replace(params.Architecture, substring, "", 1)
+		return true
+	} else if strings.Contains(params.Platform, substring) {
+		params.Platform = strings.Replace(params.Platform, substring, "", 1)
+		return true
+	} else if strings.Contains(params.PlatformVersion, substring) {
+		params.PlatformVersion = strings.Replace(params.PlatformVersion, substring, "", 1)
+		return true
+	} else if strings.Contains(params.Eol, substring) {
+		params.Eol = strings.Replace(params.Eol, substring, "", 1)
+		return true
+	} else if strings.Contains(params.Version, substring) {
+		params.Version = strings.Replace(params.Version, substring, "", 1)
+		return true
+	}
+	return false
 }

--- a/services/helpers_test.go
+++ b/services/helpers_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/chef/omnitruck-service/clients/omnitruck"
 	_ "github.com/chef/omnitruck-service/docs"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_buildEndpointUrl(t *testing.T) {
@@ -142,6 +143,102 @@ func Test_getRequestParams(t *testing.T) {
 			if got := getRequestParams(tt.ctx); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getRequestParams() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+func TestVerifyRequestType(t *testing.T) {
+	type args struct {
+		params *omnitruck.RequestParams
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "The .metadata.json is attached to Version",
+			args: args{
+				&omnitruck.RequestParams{
+					Version:         "latest.metadata.json",
+					Platform:        "amazon",
+					PlatformVersion: "2",
+					Architecture:    "x86_64",
+					Eol:             "false",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "The .metadata.json is attached to Archetecture",
+			args: args{
+				&omnitruck.RequestParams{
+					Version:         "latest",
+					Platform:        "amazon",
+					PlatformVersion: "2",
+					Architecture:    "x86_64.metadata.json",
+					Eol:             "false",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "The .metadata.json is attached to Platform",
+			args: args{
+				&omnitruck.RequestParams{
+					Version:         "latest",
+					Platform:        "amazon.metadata.json",
+					PlatformVersion: "2",
+					Architecture:    "x86_64",
+					Eol:             "false",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "The .metadata.json is attached to PlatformVersion",
+			args: args{
+				&omnitruck.RequestParams{
+					Version:         "latest",
+					Platform:        "amazon",
+					PlatformVersion: "2.metadata.json",
+					Architecture:    "x86_64",
+					Eol:             "false",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "The .metadata.json is attached to End of Life",
+			args: args{
+				&omnitruck.RequestParams{
+					Version:         "latest",
+					Platform:        "amazon",
+					PlatformVersion: "2",
+					Architecture:    "x86_64",
+					Eol:             "false.metadata.json",
+				},
+			},
+			want: true,
+		},
+		{
+			name: "The .metadata.json is not attached to any of the query parameters",
+			args: args{
+				&omnitruck.RequestParams{
+					Version:         "latest",
+					Platform:        "amazon",
+					PlatformVersion: "2",
+					Architecture:    "x86_64",
+					Eol:             "false",
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := verifyRequestType(tt.args.params)
+			assert.Equal(t, got, tt.want)
 		})
 	}
 }

--- a/services/main.go
+++ b/services/main.go
@@ -332,12 +332,12 @@ func (server *ApiService) productMetadataHandler(c *fiber.Ctx) error {
 // @Router      /{channel}/{product}/download [get]
 func (server *ApiService) productDownloadHandler(c *fiber.Ctx) error {
 	params := getRequestParams(c)
+	flag := verifyRequestType(params)
 
 	if server.Mode == Opensource && isLatest(params.Version) {
 		v, _ := server.fetchLatestOSVersion(params, c)
 		params.Version = string(v)
 	}
-
 	err, ok := server.ValidateRequest(params, c)
 	if !ok {
 		return err
@@ -347,6 +347,9 @@ func (server *ApiService) productDownloadHandler(c *fiber.Ctx) error {
 	request := server.Omnitruck(c).ProductDownload(params).ParseData(&data)
 
 	if request.Ok {
+		if flag {
+			data.Url += substring
+		}
 		server.logCtx(c).Infof("Redirecting user to %s", data.Url)
 		return c.Redirect(data.Url, 302)
 	} else {

--- a/services/main.go
+++ b/services/main.go
@@ -348,7 +348,7 @@ func (server *ApiService) productDownloadHandler(c *fiber.Ctx) error {
 
 	if request.Ok {
 		if flag {
-			data.Url += substring
+			data.Url =  data.Url + substring
 		}
 		server.logCtx(c).Infof("Redirecting user to %s", data.Url)
 		return c.Redirect(data.Url, 302)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
- Added the check if .metadata.json is present in the end of community persona url if there the give the json response with respect to the query or Information given in the request body
## Description
<!--- Describe your changes in detail, what problems does it solve? -->
- Added the check for the string `.metadata.json`
- If present if checks all the query parameter if that string is present make a bool value true and remove it from the parameter
- The request is made with that string 
- At the time of response if the `.metadata.json` was present it given the json response rather than starting a download for the product
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
- Screen Shot for the solution provided  ( If Metadata.json is present )
<img width="1792" alt="Screenshot 2023-08-21 at 1 37 59 PM" src="https://github.com/chef/omnitruck-service/assets/62262938/81a51e89-faa2-4731-a9e8-eabd70c3edd7">

- ScreenShot for the normal behaviour for the Download 
<img width="1792" alt="Screenshot 2023-08-21 at 1 47 30 PM" src="https://github.com/chef/omnitruck-service/assets/62262938/34505c76-0c8d-49b6-b899-ad51b496a295">
