### PR TITLE
fix for version/all

### DIFF
--- a/services/main.go
+++ b/services/main.go
@@ -270,6 +270,9 @@ func (server *ApiService) productVersionsHandler(c *fiber.Ctx) error {
 			data = omnitruck.FilterProductList(data, params.Product, omnitruck.EolProductVersion)
 		}
 
+		if len(data) == 0 {
+			data = append(data, "")
+		}
 		data = []omnitruck.ProductVersion{
 			data[len(data)-1],
 		}


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->
version/all api was giving error `runtime error: index out of range [-1]`

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

Before:-
<img width="1353" alt="Screenshot 2023-10-12 at 5 37 02 PM" src="https://github.com/chef/omnitruck-service/assets/97166721/6bedab5d-4d71-4f1f-8c1e-ba942e86581e">
After:-
<img width="1353" alt="Screenshot 2023-10-12 at 5 41 01 PM" src="https://github.com/chef/omnitruck-service/assets/97166721/30c70728-b8b3-41a1-89f1-4b2533d99ff2">
