### PR TITLE
Fix for the encoding of json resp

### DIFF
--- a/services/services.go
+++ b/services/services.go
@@ -1,6 +1,8 @@
 package services
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"sync"
@@ -233,8 +235,18 @@ func (server *ApiService) ValidateRequest(params *omnitruck.RequestParams, c *fi
 	return nil, true
 }
 
-func (server *ApiService) SendResponse(c *fiber.Ctx, data clients.RequestDataInterface) error {
-	return c.JSON(data)
+func (server *ApiService) JSON(c *fiber.Ctx, data interface{}) error {
+	var resultBytes bytes.Buffer
+	enc := json.NewEncoder(&resultBytes)
+	enc.SetEscapeHTML(false)
+	err := enc.Encode(data)
+	c.Context().Response.SetBodyRaw(resultBytes.Bytes())
+	c.Set(fiber.HeaderContentType, fiber.MIMEApplicationJSONCharsetUTF8)
+	return err
+}
+
+func (server *ApiService) SendResponse(c *fiber.Ctx, data interface{}) error {
+	return server.JSON(c, data)
 }
 
 func (server *ApiService) SendError(c *fiber.Ctx, request *clients.Request) error {


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

JSON response was encoding the character '<,>,&' due to which the Download URL was malformed. Have added a fix for the same.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://chefio.atlassian.net/browse/CHEF-10316

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
