### PR TITLE
Fixes for shell execution

### DIFF
--- a/templates/install.sh.tmpl
+++ b/templates/install.sh.tmpl
@@ -140,7 +140,7 @@ modify_response() {
   url=$(echo $1 | awk -F "," '{print $3}' | awk -F "\"" '{print $4}')
   version=$(echo $1 | awk -F "," '{print $4}' | awk -F "\"" '{print $4}')
   sha256=$(echo $1 | awk -F "," '{print $2}' | awk -F "\"" '{print $4}')
-  echo -e "sha256 $sha256\nurl $url\nversion $version" > "$2"
+  printf "sha256 $sha256\nurl $url\nversion $version" > "$2"
 }
 
 # do_curl URL FILENAME


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
Corrected the linux template for shell execution. "echo -e" is not available for shell execution due to which the script was failing with sh. Replaced it with printf to make it available for both sh and bash

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://progresssoftware.atlassian.net/browse/CHEF-16349

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
