### PR TITLE
Adjusted the URL when the package manager is not required for certain products

### DIFF
--- a/internal/api/handler/handler_test.go
+++ b/internal/api/handler/handler_test.go
@@ -437,7 +437,7 @@ func TestProductMetadataHandler(t *testing.T) {
 			serverMode:       constants.Trial,
 			requestPath:      "/stable/automate/metadata?p=linux&m=amd64&eol=false&v=latest",
 			expectedStatus:   fiber.StatusOK,
-			expectedResponse: `{"sha1":"", "sha256":"1234", "url":"http://example.com/stable/automate/download?eol=false&m=amd64&p=linux&pm=pm&v=latest", "version":"latest"}`,
+			expectedResponse: `{"sha1":"", "sha256":"1234", "url":"http://example.com/stable/automate/download?eol=false&m=amd64&p=linux&v=latest", "version":"latest"}`,
 			metadata: models.MetaData{
 				Architecture:    "amd64",
 				FileName:        "",
@@ -539,7 +539,7 @@ func TestProductMetadataHandler(t *testing.T) {
 			serverMode:       constants.Opensource,
 			requestPath:      "/stable/habitat/metadata?p=linux&m=x86_64&eol=false",
 			expectedStatus:   fiber.StatusOK,
-			expectedResponse: `{"sha1":"", "sha256":"abcd", "url":"http://example.com/stable/habitat/download?eol=false&m=x86_64&p=linux&pm=pm&v=0.9.3", "version":"0.9.3"}`,
+			expectedResponse: `{"sha1":"", "sha256":"abcd", "url":"http://example.com/stable/habitat/download?eol=false&m=x86_64&p=linux&v=0.9.3", "version":"0.9.3"}`,
 			metadata: models.MetaData{
 				Architecture:    "x86_64",
 				FileName:        "",

--- a/internal/helper/helpers.go
+++ b/internal/helper/helpers.go
@@ -7,16 +7,22 @@ import (
 	"strings"
 
 	"github.com/chef/omnitruck-service/clients/omnitruck"
+	"github.com/chef/omnitruck-service/constants"
 	"github.com/gofiber/fiber/v2"
 )
 
 const substring = ".metadata.json"
 
 func BuildEndpointUrl(baseUrl string, endpoint string, params *omnitruck.RequestParams) *url.URL {
+	clonedParams := *params
+	if clonedParams.PackageManager == constants.DUMMY_PACKAGE_MANAGER {
+		clonedParams.PackageManager = ""
+	}
 	u, _ := url.Parse(baseUrl)
-	path, _ := url.JoinPath(params.Channel, params.Product, endpoint)
+
+	path, _ := url.JoinPath(clonedParams.Channel, clonedParams.Product, endpoint)
 	u.Path = path
-	u.RawQuery = params.UrlParams().Encode()
+	u.RawQuery = clonedParams.UrlParams().Encode()
 
 	return u
 }

--- a/internal/helper/helpers_test.go
+++ b/internal/helper/helpers_test.go
@@ -54,6 +54,23 @@ func Test_buildEndpointUrl(t *testing.T) {
 			},
 			want: "https://trial.chef.io/stable/chef-ice/download?eol=false&m=x86_64&p=linux&pm=rpm&v=19.7.17",
 		},
+		{
+			name: "habitat download URL",
+			args: args{
+				baseUrl:  "https://trial.chef.io",
+				endpoint: "download",
+				params: omnitruck.RequestParams{
+					Channel:        "stable",
+					Product:        "habitat",
+					Eol:            "false",
+					Version:        "19.7.17",
+					Architecture:   "x86_64",
+					Platform:       "ubuntu",
+					PackageManager: "pm",
+				},
+			},
+			want: "https://trial.chef.io/stable/habitat/download?eol=false&m=x86_64&p=ubuntu&v=19.7.17",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This PR fixes the url field in the metadata API response to return the correct download URL when the pm (package manager) parameter is set to a placeholder value (pm).

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
<img width="999" height="439" alt="image" src="https://github.com/user-attachments/assets/9f25f7f1-3619-4e6a-ae19-081bd8b9ec9b" />

