### PR TITLE
Fix: Remove pm from metadata URL for non-infra products

### DIFF
--- a/internal/strategy/default_product_strategy.go
+++ b/internal/strategy/default_product_strategy.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/chef/omnitruck-service/clients"
 	"github.com/chef/omnitruck-service/clients/omnitruck"
+	"github.com/chef/omnitruck-service/constants"
 	helpers "github.com/chef/omnitruck-service/internal/helper"
 	"github.com/gofiber/fiber/v2"
 	log "github.com/sirupsen/logrus"
@@ -40,6 +41,7 @@ func (s *DefaultProductStrategy) GetPackages(params *omnitruck.RequestParams) (o
 
 func (s *DefaultProductStrategy) GetMetadata(params *omnitruck.RequestParams) (omnitruck.PackageMetadata, *clients.Request) {
 	var data omnitruck.PackageMetadata
+	params.PackageManager = constants.DUMMY_PACKAGE_MANAGER
 	request := s.OmnitruckService.ProductMetadata(params).ParseData(&data)
 	return data, request
 }

--- a/internal/strategy/platform_service_strategy.go
+++ b/internal/strategy/platform_service_strategy.go
@@ -59,6 +59,7 @@ func (s *PlatformServiceStrategy) GetPackages(params *omnitruck.RequestParams) (
 
 func (s *PlatformServiceStrategy) GetMetadata(params *omnitruck.RequestParams) (omnitruck.PackageMetadata, *clients.Request) {
 	request := &clients.Request{}
+	params.PackageManager = constants.DUMMY_PACKAGE_MANAGER
 	data, err := s.PlatformService.PlatformMetadata(params, int(s.Mode))
 	if err != nil {
 		code, msg := helpers.GetErrorCodeAndMsg(err)


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
This PR fixes a issue in the metadata API where the pm (package manager) query param was incorrectly being included in the final download URL for non-infra 19 products.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
