### PR TITLE
Partial version support

### DIFF
--- a/internal/helper/helpers_test.go
+++ b/internal/helper/helpers_test.go
@@ -288,7 +288,7 @@ func TestValidateOrSetVersion(t *testing.T) {
 		expectVer   string
 	}{
 		{
-			name: "valid version exists",
+			name: "valid version exists - full version",
 			params: &omnitruck.RequestParams{
 				Version: "2.0.0",
 			},
@@ -321,6 +321,57 @@ func TestValidateOrSetVersion(t *testing.T) {
 			filtered:    []omnitruck.ProductVersion{"4.0.0", "5.0.0"},
 			expectError: false,
 			expectVer:   "5.0.0",
+		},
+		{
+			name: "major version only - gets latest of that major",
+			params: &omnitruck.RequestParams{
+				Version: "16",
+			},
+			filtered:    []omnitruck.ProductVersion{"15.0.0", "16.1.0", "16.2.5", "16.3.10", "17.0.0"},
+			expectError: false,
+			expectVer:   "16.3.10",
+		},
+		{
+			name: "major.minor version - gets latest patch of that combo",
+			params: &omnitruck.RequestParams{
+				Version: "16.2",
+			},
+			filtered:    []omnitruck.ProductVersion{"16.1.0", "16.2.0", "16.2.3", "16.2.5", "16.3.0", "17.0.0"},
+			expectError: false,
+			expectVer:   "16.2.5",
+		},
+		{
+			name: "major version not found",
+			params: &omnitruck.RequestParams{
+				Version: "99",
+			},
+			filtered:    []omnitruck.ProductVersion{"1.0.0", "2.0.0"},
+			expectError: true,
+		},
+		{
+			name: "major.minor version not found",
+			params: &omnitruck.RequestParams{
+				Version: "16.99",
+			},
+			filtered:    []omnitruck.ProductVersion{"16.1.0", "16.2.0", "17.0.0"},
+			expectError: true,
+		},
+		{
+			name: "full version with multiple matching major.minor",
+			params: &omnitruck.RequestParams{
+				Version: "16.2.3",
+			},
+			filtered:    []omnitruck.ProductVersion{"16.2.0", "16.2.3", "16.2.5"},
+			expectError: false,
+			expectVer:   "16.2.3",
+		},
+		{
+			name: "full version not found even with matching major.minor",
+			params: &omnitruck.RequestParams{
+				Version: "16.2.4",
+			},
+			filtered:    []omnitruck.ProductVersion{"16.2.0", "16.2.3", "16.2.5"},
+			expectError: true,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This pull request improves the logic for handling version selection in the `ValidateOrSetVersion` function and expands the corresponding unit tests to cover more scenarios. The main change is that the function now supports partial version matching (major or major.minor) and always selects the latest matching version, ensuring more flexible and robust version resolution.

**Version selection logic improvements:**

* Updated `ValidateOrSetVersion` in `internal/helper/helpers.go` to support partial version matching (e.g., "16" or "16.2"), efficiently finding and setting the latest matching version, and ensuring proper boundaries to avoid incorrect matches.

**Unit tests enhancements:**

* Added multiple new test cases to `TestValidateOrSetVersion` in `internal/helper/helpers_test.go`, covering scenarios such as major-only, major.minor, full version matches, and cases where no match is found. This ensures comprehensive coverage of the new matching logic.
* Clarified the naming of an existing test case to explicitly indicate it checks for a full version match.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->
https://progresssoftware.atlassian.net/browse/CHEF-29022

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).

### Demo
https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/IQAoyYwFxxL7SbQMyyWcKd28AWhu2KmFIrmw9eCq13Sd96s?e=0KQvnB
