### PR TITLE
Leverage pre-signed URL instead of streaming via S3

### DIFF
--- a/clients/omnitruck/aws/s3_mocks.go
+++ b/clients/omnitruck/aws/s3_mocks.go
@@ -16,6 +16,7 @@ var (
 	MockNewS3SessionFunc     func(region string) (aws.Config, error)
 	MockNewS3CredentialsFunc func(cfg aws.Config, roleArn string) aws.CredentialsProvider
 	MockGetS3ObjectFunc      func(ctx context.Context, cfg aws.Config, creds aws.CredentialsProvider, bucket, key string) (*s3.GetObjectOutput, error)
+	MockGetS3PresignedURLFunc func(ctx context.Context, cfg aws.Config, creds aws.CredentialsProvider, bucket, key string, expirationMinutes int) (string, error)
 )
 
 func MockValidateS3Config(cfg omnitruckConfig.AWSConfig) error {
@@ -29,4 +30,7 @@ func MockNewS3Credentials(cfg aws.Config, roleArn string) aws.CredentialsProvide
 }
 func MockGetS3Object(ctx context.Context, cfg aws.Config, creds aws.CredentialsProvider, bucket, key string) (*s3.GetObjectOutput, error) {
 	return MockGetS3ObjectFunc(ctx, cfg, creds, bucket, key)
+}
+func MockGetS3PresignedURL(ctx context.Context, cfg aws.Config, creds aws.CredentialsProvider, bucket, key string, expirationMinutes int) (string, error) {
+	return MockGetS3PresignedURLFunc(ctx, cfg, creds, bucket, key, expirationMinutes)
 }

--- a/clients/omnitruck/aws/s3_presigned_test.go
+++ b/clients/omnitruck/aws/s3_presigned_test.go
@@ -1,0 +1,31 @@
+package aws
+
+import (
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetS3PresignedURL(t *testing.T) {
+	cfg, err := NewS3Session("us-east-1")
+	assert.NoError(t, err)
+
+	creds := NewS3Credentials(cfg, "arn:aws:iam::123456789012:role/test-role")
+
+	// Note: This will fail without valid AWS credentials, but tests the function signature
+	_, err = GetS3PresignedURL(context.Background(), cfg, creds, "test-bucket", "test-key", 15)
+	// We expect an error since we don't have valid credentials in test
+	assert.Error(t, err)
+}
+
+func TestMockGetS3PresignedURL(t *testing.T) {
+	MockGetS3PresignedURLFunc = func(ctx context.Context, cfg aws.Config, creds aws.CredentialsProvider, bucket, key string, expirationMinutes int) (string, error) {
+		return "https://test-bucket.s3.amazonaws.com/test-key?presigned=true", nil
+	}
+
+	url, err := MockGetS3PresignedURL(context.Background(), aws.Config{}, nil, "test-bucket", "test-key", 15)
+	assert.NoError(t, err)
+	assert.Equal(t, "https://test-bucket.s3.amazonaws.com/test-key?presigned=true", url)
+}


### PR DESCRIPTION
This offloads the heavy lifting from the API and removes it as a point of contention

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
