### PR TITLE
Added the files api endpoint

### DIFF
--- a/clients/omnitruck/omnitruck.go
+++ b/clients/omnitruck/omnitruck.go
@@ -52,6 +52,8 @@ type RequestParams struct {
 	Eol             string
 	LicenseId       string
 	BOM             string
+	Direct          string
+	FileName        string
 }
 
 type RequestParamsFlags struct {
@@ -73,6 +75,7 @@ type IOmnitruck interface {
 	ProductPackages(params *RequestParams) *clients.Request
 	ProductMetadata(params *RequestParams) *clients.Request
 	ProductDownload(params *RequestParams) *clients.Request
+	Architectures() *clients.Request
 }
 
 type PackageListUpdater func(platform string, platformVersion string, arch string, meta PackageMetadata) PackageMetadata

--- a/clients/omnitruck/omnitruck_mock.go
+++ b/clients/omnitruck/omnitruck_mock.go
@@ -1,4 +1,5 @@
 package omnitruck
+
 import "github.com/chef/omnitruck-service/clients"
 
 type MockOmnitruck struct {
@@ -7,6 +8,7 @@ type MockOmnitruck struct {
 	ProductPackagesFunc func(params *RequestParams) *clients.Request
 	ProductMetadataFunc func(params *RequestParams) *clients.Request
 	ProductDownloadFunc func(params *RequestParams) *clients.Request
+	ArchtechtureFunc    func() *clients.Request
 }
 
 func (m *MockOmnitruck) LatestVersion(params *RequestParams) *clients.Request {
@@ -36,6 +38,12 @@ func (m *MockOmnitruck) ProductMetadata(params *RequestParams) *clients.Request 
 func (m *MockOmnitruck) ProductDownload(params *RequestParams) *clients.Request {
 	if m.ProductDownloadFunc != nil {
 		return m.ProductDownloadFunc(params)
+	}
+	return nil
+}
+func (m *MockOmnitruck) Architectures() *clients.Request {
+	if m.ArchtechtureFunc != nil {
+		return m.ArchtechtureFunc()
 	}
 	return nil
 }

--- a/httpserver/routes.go
+++ b/httpserver/routes.go
@@ -54,6 +54,7 @@ func (server *ApiServer) buildRouter() {
 	server.App.Get("/:channel/:product/packages", requestid.New(), handler.ProductPackagesHandler)
 	server.App.Get("/:channel/:product/metadata", requestid.New(), handler.ProductMetadataHandler)
 	server.App.Get("/:channel/:product/download", requestid.New(), handler.ProductDownloadHandler)
+	server.App.Get("/files/:channel/:product/:version/:platform/*", requestid.New(), handler.ProductFilesDownloadHandler)
 	server.App.Get("/relatedProducts", requestid.New(), handler.RelatedProductsHandler)
 	server.App.Get("/:channel/:product/fileName", requestid.New(), handler.FileNameHandler)
 	server.App.Get("/install.sh", requestid.New(), handler.DownloadLinuxScript)

--- a/internal/api/handler/handler.go
+++ b/internal/api/handler/handler.go
@@ -344,6 +344,51 @@ func (h *DownloadsHandler) ProductDownloadHandler(c *fiber.Ctx) error {
 	if err != nil {
 		return h.SendErrorResponse(c, code, msg)
 	}
+	return h.sendDownloadResponse(c, url, downloadResp, header)
+}
+
+// @Summary Download a product package using path params
+// @description Path-param variant of download endpoint. Architecture is always passed in path; package manager is path-based only for infra products.
+// @description Tail formats:
+// @description Default: `{platformVersion}/{arch}/{fileName}`
+// @description Automate/Habitat: `{arch}/{fileName}`
+// @description Infra: `{arch}/{fileName}` or `{arch}/{pm}/{fileName}`
+// @Accept      json
+// @Produce     json
+// @Param       channel    path   string true  "Channel" Enums(current, stable)
+// @Param       product    path   string true  "Product" Example(chef)
+// @Param       version    path   string true  "Version" Example(latest)
+// @Param       platform   path   string true  "Platform" Example(linux)
+// @Param       tail       path   string true  "Path tail containing platformVersion/arch/pm/fileName by product strategy"
+// @Param       license_id query  string false "License ID"
+// @Param       eol        query  bool   false "EOL Products" Default(false)
+// @Success     302
+// @Failure     400 {object} ErrorResponse
+// @Failure     403 {object} ErrorResponse
+// @Router      /files/{channel}/{product}/{version}/{platform}/{tail} [get]
+func (h *DownloadsHandler) ProductFilesDownloadHandler(c *fiber.Ctx) error {
+	reqInjectorI := c.Locals("reqinjector")
+	reqInjector, ok := reqInjectorI.(*do.Injector)
+	if !ok {
+		return h.SendErrorResponse(c, http.StatusInternalServerError, "Not able to process the request.")
+	}
+
+	locals := setLocals(c)
+
+	downloadService, err := services.NewDownloadService(reqInjector, h.Log, locals)
+	if err != nil {
+		return h.SendErrorResponse(c, http.StatusInternalServerError, "Failed to create download service")
+	}
+
+	url, downloadResp, header, msg, code, err := downloadService.ProductFilesDownload(c)
+	if err != nil {
+		return h.SendErrorResponse(c, code, msg)
+	}
+
+	return h.sendDownloadResponse(c, url, downloadResp, header)
+}
+
+func (h *DownloadsHandler) sendDownloadResponse(c *fiber.Ctx, url string, downloadResp io.ReadCloser, header http.Header) error {
 	if downloadResp != nil {
 		// If the response is not nil, it means we are returning a file download
 

--- a/internal/api/handler/handler_test.go
+++ b/internal/api/handler/handler_test.go
@@ -1677,6 +1677,202 @@ func TestProductDownloadHandler(t *testing.T) {
 	}
 }
 
+func TestProductMetadataHandler_DirectUrl(t *testing.T) {
+	app := fiber.New()
+	app.Use(func(c *fiber.Ctx) error {
+		c.Locals("base_url", "http://example.com")
+		return c.Next()
+	})
+
+	mockDbService := new(dboperations.MockIDbOperations)
+	mockDbService.GetMetaDatafunc = func(partitionValue, sortValue, platform, platformVersion, architecture, packageManager string) (*models.MetaData, error) {
+		return &models.MetaData{
+			Architecture: architecture,
+			Platform:     platform,
+			FileName:     "automate_4.7.52-1_amd64.deb",
+			SHA256:       "abcd",
+		}, nil
+	}
+	mockDbService.GetVersionLatestfunc = func(partitionValue string) (string, error) {
+		return "latest", nil
+	}
+	mockDbService.GetVersionAllfunc = func(partitionValue string) ([]string, error) {
+		return []string{"latest"}, nil
+	}
+	mockDbService.SetDbInfofunc = func(tableName string, dbModel reflect.Type) {}
+
+	log := logrus.NewEntry(logrus.New())
+	handler := NewDownloadsHandler(log)
+	app.Use(testInjector(mockDbService, constants.Commercial, &template.MockTemplateRenderer{}))
+	app.Get("/:channel/:product/metadata", func(c *fiber.Ctx) error {
+		return handler.ProductMetadataHandler(c)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/stable/automate/metadata?p=linux&m=amd64&v=latest&direct=true&eol=false", nil)
+	resp, err := app.Test(req, 100*1000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	bodyBytes, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"sha1":"","sha256":"abcd","url":"http://example.com/files/stable/automate/latest/linux/amd64/automate_4.7.52-1_amd64.deb?license_id=","version":"latest"}`, string(bodyBytes))
+}
+
+func TestProductPackagesHandler_DirectUrl(t *testing.T) {
+	app := fiber.New()
+	app.Use(func(c *fiber.Ctx) error {
+		c.Locals("base_url", "http://example.com")
+		return c.Next()
+	})
+
+	mockDbService := new(dboperations.MockIDbOperations)
+	mockDbService.GetPackagesfunc = func(partitionValue, sortValue string) (interface{}, error) {
+		return &models.ProductDetails{
+			Product: "automate",
+			Version: "latest",
+			MetaData: []models.MetaData{{
+				Architecture: "amd64",
+				Platform:     "linux",
+				SHA256:       "abcd",
+			}},
+		}, nil
+	}
+	mockDbService.GetMetaDatafunc = func(partitionValue, sortValue, platform, platformVersion, architecture, packageManager string) (*models.MetaData, error) {
+		return &models.MetaData{
+			Architecture: architecture,
+			Platform:     platform,
+			FileName:     "automate_4.7.52-1_amd64.deb",
+			SHA256:       "abcd",
+		}, nil
+	}
+	mockDbService.GetVersionLatestfunc = func(partitionValue string) (string, error) {
+		return "latest", nil
+	}
+	mockDbService.GetVersionAllfunc = func(partitionValue string) ([]string, error) {
+		return []string{"latest"}, nil
+	}
+	mockDbService.SetDbInfofunc = func(tableName string, dbModel reflect.Type) {}
+
+	log := logrus.NewEntry(logrus.New())
+	handler := NewDownloadsHandler(log)
+	app.Use(testInjector(mockDbService, constants.Commercial, &template.MockTemplateRenderer{}))
+	app.Get("/:channel/:product/packages", func(c *fiber.Ctx) error {
+		return handler.ProductPackagesHandler(c)
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/stable/automate/packages?v=latest&direct=true&eol=false", nil)
+	resp, err := app.Test(req, 100*1000)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	bodyBytes, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"linux":{"pv":{"amd64":{"sha1":"","sha256":"abcd","url":"http://example.com/files/stable/automate/latest/linux/amd64/automate_4.7.52-1_amd64.deb?license_id=","version":"latest"}}}}`, string(bodyBytes))
+}
+
+func TestProductFilesHandler(t *testing.T) {
+	log := logrus.NewEntry(logrus.New())
+	handler := NewDownloadsHandler(log)
+
+	t.Run("files route redirects for automate", func(t *testing.T) {
+		app := fiber.New()
+		app.Use(testInjector(&dboperations.MockIDbOperations{
+			GetMetaDatafunc: func(partitionValue, sortValue, platform, platformVersion, architecture, packageManager string) (*models.MetaData, error) {
+				assert.Equal(t, "", packageManager)
+				assert.Equal(t, "amd64", architecture)
+				return &models.MetaData{FileName: "chef-automate_linux_amd64.zip"}, nil
+			},
+			GetVersionLatestfunc: func(partitionValue string) (string, error) {
+				return "latest", nil
+			},
+			GetVersionAllfunc: func(partitionValue string) ([]string, error) {
+				return []string{"latest"}, nil
+			},
+			SetDbInfofunc: func(tableName string, dbModel reflect.Type) {},
+		}, constants.Commercial, &template.MockTemplateRenderer{}))
+		app.Get("/files/:channel/:product/:version/:platform/*", handler.ProductFilesDownloadHandler)
+
+		req := httptest.NewRequest(http.MethodGet, "/files/current/automate/latest/linux/amd64/chef-automate_linux_amd64.zip?eol=false", nil)
+		resp, err := app.Test(req, 100*1000)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusFound, resp.StatusCode)
+	})
+
+	t.Run("files route validation fails when arch cannot be inferred", func(t *testing.T) {
+		app := fiber.New()
+		app.Use(testInjector(&dboperations.MockIDbOperations{
+			GetVersionAllfunc: func(partitionValue string) ([]string, error) {
+				return []string{"latest"}, nil
+			},
+			SetDbInfofunc: func(tableName string, dbModel reflect.Type) {},
+		}, constants.Commercial, &template.MockTemplateRenderer{}))
+		app.Get("/files/:channel/:product/:version/:platform/*", handler.ProductFilesDownloadHandler)
+
+		req := httptest.NewRequest(http.MethodGet, "/files/current/automate/latest/linux/chef-noarch.pkg?eol=false", nil)
+		resp, err := app.Test(req, 100*1000)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		bodyBytes, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"code":400, "message":"Architecture (m) params cannot be empty", "status_text":"Bad Request"}`, string(bodyBytes))
+	})
+
+	t.Run("files route validation fails when arch path and filename mismatch", func(t *testing.T) {
+		app := fiber.New()
+		app.Use(testInjector(&dboperations.MockIDbOperations{
+			GetVersionAllfunc: func(partitionValue string) ([]string, error) {
+				return []string{"latest"}, nil
+			},
+			SetDbInfofunc: func(tableName string, dbModel reflect.Type) {},
+		}, constants.Commercial, &template.MockTemplateRenderer{}))
+		app.Get("/files/:channel/:product/:version/:platform/*", handler.ProductFilesDownloadHandler)
+
+		req := httptest.NewRequest(http.MethodGet, "/files/current/automate/latest/linux/aarch64/chef-18.2.7-1.el6.x86_64.rpm?eol=false", nil)
+		resp, err := app.Test(req, 100*1000)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		bodyBytes, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"code":400, "message":"architecture path param does not match filename", "status_text":"Bad Request"}`, string(bodyBytes))
+	})
+
+	t.Run("files route validation fails when default strategy platform_version missing", func(t *testing.T) {
+		app := fiber.New()
+		app.Use(testInjector(&dboperations.MockIDbOperations{
+			GetVersionAllfunc: func(partitionValue string) ([]string, error) {
+				return []string{"latest"}, nil
+			},
+			SetDbInfofunc: func(tableName string, dbModel reflect.Type) {},
+		}, constants.Commercial, &template.MockTemplateRenderer{}))
+		app.Get("/files/:channel/:product/:version/:platform/*", handler.ProductFilesDownloadHandler)
+
+		req := httptest.NewRequest(http.MethodGet, "/files/current/chef/latest/linux/x86_64/chef-18.2.7-1.el6.x86_64.rpm?eol=false", nil)
+		resp, err := app.Test(req, 100*1000)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		bodyBytes, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"code":400, "message":"Platform Version (pv) params cannot be empty", "status_text":"Bad Request"}`, string(bodyBytes))
+	})
+
+	t.Run("files route validation fails when infra package manager missing", func(t *testing.T) {
+		app := fiber.New()
+		app.Use(testInjector(&dboperations.MockIDbOperations{
+			GetVersionAllfunc: func(partitionValue string) ([]string, error) {
+				return []string{"latest"}, nil
+			},
+			SetDbInfofunc: func(tableName string, dbModel reflect.Type) {},
+		}, constants.Commercial, &template.MockTemplateRenderer{}))
+		app.Get("/files/:channel/:product/:version/:platform/*", handler.ProductFilesDownloadHandler)
+
+		req := httptest.NewRequest(http.MethodGet, "/files/current/chef-ice/latest/linux/x86_64/chef-ice-19.2.106-1.amzn2.x86_64.rpm?eol=false", nil)
+		resp, err := app.Test(req, 100*1000)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+		bodyBytes, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{"code":400, "message":"Package Manager (pm) params cannot be empty", "status_text":"Bad Request"}`, string(bodyBytes))
+	})
+}
+
 func TestPlatformsHandler(t *testing.T) {
 	t.Parallel()
 

--- a/internal/helper/helpers.go
+++ b/internal/helper/helpers.go
@@ -13,6 +13,20 @@ import (
 
 const substring = ".metadata.json"
 
+// FilesPathParams holds the parsed components extracted from the /files URL path tail.
+type FilesPathParams struct {
+	PlatformVersion string
+	Architecture    string
+	PackageManager  string
+	FileName        string
+}
+
+// TailParser is implemented by each ProductStrategy to parse the /files URL path tail
+// according to that product's segment layout.
+type TailParser interface {
+	ParseTail(segments []string) FilesPathParams
+}
+
 func BuildEndpointUrl(baseUrl string, endpoint string, params *omnitruck.RequestParams) *url.URL {
 	clonedParams := *params
 	if clonedParams.PackageManager == constants.DUMMY_PACKAGE_MANAGER {
@@ -31,6 +45,70 @@ func GetDownloadUrl(params *omnitruck.RequestParams, baseUrl string) string {
 	return BuildEndpointUrl(baseUrl, "download", params).String()
 }
 
+// filesURLBuilder holds all components needed to construct a /files endpoint URL.
+type filesURLBuilder struct {
+	baseURL         string
+	channel         string
+	product         string
+	version         string
+	platform        string
+	platformVersion string
+	architecture    string
+	packageManager  string
+	fileName        string
+	licenseID       string
+}
+
+func (b filesURLBuilder) build() string {
+	u, _ := url.Parse(b.baseURL)
+	segments := []string{"files", b.channel, b.product, b.version, b.platform}
+	if b.platformVersion != "" {
+		segments = append(segments, b.platformVersion)
+	}
+	segments = append(segments, b.architecture)
+	if b.packageManager != "" && b.packageManager != constants.DUMMY_PACKAGE_MANAGER {
+		segments = append(segments, b.packageManager)
+	}
+	segments = append(segments, b.fileName)
+	path, _ := url.JoinPath("", segments...)
+	u.Path = path
+	q := url.Values{}
+	q.Set("license_id", b.licenseID)
+	u.RawQuery = q.Encode()
+	return u.String()
+}
+
+// GetFilesUrl constructs a /files endpoint URL. pathPackageManager should be non-empty
+// only when the package manager segment must appear in the path (e.g. infra products).
+func GetFilesUrl(params *omnitruck.RequestParams, baseUrl string, fileName string, pathPackageManager string) string {
+	return filesURLBuilder{
+		baseURL:         baseUrl,
+		channel:         params.Channel,
+		product:         params.Product,
+		version:         params.Version,
+		platform:        params.Platform,
+		platformVersion: params.PlatformVersion,
+		architecture:    params.Architecture,
+		packageManager:  pathPackageManager,
+		fileName:        fileName,
+		licenseID:       params.LicenseId,
+	}.build()
+}
+
+// GetPackageUrl routes to /files when direct=true, otherwise to /download.
+// For infra products, PM is included in the path when available (and not dummy value).
+func GetPackageUrl(params *omnitruck.RequestParams, baseUrl string, fileName string) string {
+	if strings.EqualFold(params.Direct, "true") && fileName != "" {
+		// Only pass PM if it's not the dummy placeholder
+		pm := ""
+		if params.PackageManager != "" && params.PackageManager != constants.DUMMY_PACKAGE_MANAGER {
+			pm = params.PackageManager
+		}
+		return GetFilesUrl(params, baseUrl, fileName, pm)
+	}
+	return GetDownloadUrl(params, baseUrl)
+}
+
 func GetRequestParams(c omnitruck.FiberContext) *omnitruck.RequestParams {
 	return &omnitruck.RequestParams{
 		Channel:         c.Params("channel"),
@@ -43,7 +121,50 @@ func GetRequestParams(c omnitruck.FiberContext) *omnitruck.RequestParams {
 		LicenseId:       c.Query("license_id"),
 		Eol:             c.Query("eol", "false"),
 		BOM:             c.Query(("bom")),
+		Direct:          c.Query("direct"),
 	}
+}
+
+// GetFilesRequestParamsWithStrategy parses the /files URL path tail using the
+// strategy-owned parser and returns a fully populated RequestParams.
+func GetFilesRequestParamsWithStrategy(c omnitruck.FiberContext, parser TailParser) *omnitruck.RequestParams {
+	segments := strings.Split(strings.Trim(c.Params("*"), "/"), "/")
+	parsed := parser.ParseTail(segments)
+
+	return &omnitruck.RequestParams{
+		Channel:         c.Params("channel"),
+		Product:         c.Params("product"),
+		Version:         c.Params("version"),
+		Platform:        c.Params("platform"),
+		PlatformVersion: parsed.PlatformVersion,
+		Architecture:    parsed.Architecture,
+		PackageManager:  parsed.PackageManager,
+		FileName:        parsed.FileName,
+		LicenseId:       c.Query("license_id"),
+		Eol:             c.Query("eol", "false"),
+	}
+}
+
+func ValidateCommonRequiredFilesParams(params *omnitruck.RequestParams) error {
+	if params == nil {
+		return errors.New("request params cannot be empty")
+	}
+	if strings.TrimSpace(params.Channel) == "" {
+		return errors.New("Channel path param cannot be empty")
+	}
+	if strings.TrimSpace(params.Product) == "" {
+		return errors.New("Product path param cannot be empty")
+	}
+	if strings.TrimSpace(params.Platform) == "" {
+		return errors.New("Platform path param cannot be empty")
+	}
+	if strings.TrimSpace(params.FileName) == "" {
+		return errors.New("Filename path param cannot be empty")
+	}
+	if strings.TrimSpace(params.Architecture) == "" {
+		return errors.New("Architecture (m) params cannot be empty")
+	}
+	return nil
 }
 
 func VerifyRequestType(params *omnitruck.RequestParams) bool {

--- a/internal/helper/helpers_test.go
+++ b/internal/helper/helpers_test.go
@@ -3,12 +3,15 @@ package helpers
 import (
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/chef/omnitruck-service/clients/omnitruck"
+	"github.com/chef/omnitruck-service/constants"
 	_ "github.com/chef/omnitruck-service/docs"
 	"github.com/gofiber/fiber/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_buildEndpointUrl(t *testing.T) {
@@ -179,6 +182,309 @@ func Test_getRequestParams(t *testing.T) {
 			if got := GetRequestParams(tt.ctx); !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("getRequestParams() = %v, want %v", got, tt.want)
 			}
+		})
+	}
+}
+
+// Inline TailParser implementations used only in tests.
+type defaultTailParser struct{}
+
+func (p *defaultTailParser) ParseTail(segments []string) FilesPathParams {
+	result := FilesPathParams{}
+	switch len(segments) {
+	case 1:
+		result.FileName = segments[0]
+	case 2:
+		result.Architecture = segments[0]
+		result.FileName = segments[1]
+	default:
+		if len(segments) > 2 {
+			result.PlatformVersion = segments[0]
+			result.Architecture = segments[1]
+			result.FileName = strings.Join(segments[2:], "/")
+		}
+	}
+	return result
+}
+
+type infraTailParser struct{}
+
+func (p *infraTailParser) ParseTail(segments []string) FilesPathParams {
+	result := FilesPathParams{}
+	switch len(segments) {
+	case 1:
+		result.FileName = segments[0]
+	case 2:
+		result.Architecture = segments[0]
+		result.FileName = segments[1]
+	default:
+		if len(segments) > 2 {
+			result.Architecture = segments[0]
+			result.PackageManager = segments[1]
+			result.FileName = strings.Join(segments[2:], "/")
+		}
+	}
+	return result
+}
+
+type automateTailParser struct{}
+
+func (p *automateTailParser) ParseTail(segments []string) FilesPathParams {
+	result := FilesPathParams{}
+	switch len(segments) {
+	case 1:
+		result.FileName = segments[0]
+	case 2:
+		result.Architecture = segments[0]
+		result.FileName = segments[1]
+	default:
+		if len(segments) > 1 {
+			result.Architecture = segments[0]
+			result.FileName = strings.Join(segments[1:], "/")
+		}
+	}
+	return result
+}
+
+func TestGetFilesRequestParams(t *testing.T) {
+	tests := []struct {
+		name   string
+		ctx    omnitruck.FiberContext
+		parser TailParser
+		want   *omnitruck.RequestParams
+	}{
+		{
+			name:   "default path parses platformVersion and architecture",
+			parser: &defaultTailParser{},
+			ctx: &testContext{
+				params: map[string]string{
+					"channel":  "stable",
+					"product":  "chef",
+					"version":  "18.2.7",
+					"platform": "el",
+					"*":        "6/x86_64/chef-18.2.7-1.el6.x86_64.rpm",
+				},
+				query: map[string]string{
+					"license_id": "abc-123",
+					"eol":        "false",
+				},
+			},
+			want: &omnitruck.RequestParams{
+				Channel:         "stable",
+				Product:         "chef",
+				Version:         "18.2.7",
+				Platform:        "el",
+				PlatformVersion: "6",
+				FileName:        "chef-18.2.7-1.el6.x86_64.rpm",
+				Architecture:    "x86_64",
+				PackageManager:  "",
+				LicenseId:       "abc-123",
+				Eol:             "false",
+			},
+		},
+		{
+			name:   "infra path parses architecture and package manager",
+			parser: &infraTailParser{},
+			ctx: &testContext{
+				params: map[string]string{
+					"channel":  "stable",
+					"product":  "chef-ice",
+					"version":  "19.2.106",
+					"platform": "linux",
+					"*":        "x86_64/tar/chef-ice-19.2.106-1.amzn2.x86_64.rpm",
+				},
+				query: map[string]string{
+					"license_id": "52c218ef-3444-49f9-9c8b-28dfa204cd74",
+					"eol":        "false",
+				},
+			},
+			want: &omnitruck.RequestParams{
+				Channel:         "stable",
+				Product:         "chef-ice",
+				Version:         "19.2.106",
+				Platform:        "linux",
+				PlatformVersion: "",
+				FileName:        "chef-ice-19.2.106-1.amzn2.x86_64.rpm",
+				Architecture:    "x86_64",
+				PackageManager:  "tar",
+				LicenseId:       "52c218ef-3444-49f9-9c8b-28dfa204cd74",
+				Eol:             "false",
+			},
+		},
+		{
+			name:   "files path does not fallback to query m and pm",
+			parser: &infraTailParser{},
+			ctx: &testContext{
+				params: map[string]string{
+					"channel":  "stable",
+					"product":  "chef-ice",
+					"version":  "19.2.106",
+					"platform": "linux",
+					"*":        "chef-ice-19.2.106-1.amzn2.x86_64.rpm",
+				},
+				query: map[string]string{
+					"license_id": "52c218ef-3444-49f9-9c8b-28dfa204cd74",
+					"m":          "x86_64",
+					"pm":         "tar",
+					"eol":        "false",
+				},
+			},
+			want: &omnitruck.RequestParams{
+				Channel:         "stable",
+				Product:         "chef-ice",
+				Version:         "19.2.106",
+				Platform:        "linux",
+				PlatformVersion: "",
+				FileName:        "chef-ice-19.2.106-1.amzn2.x86_64.rpm",
+				Architecture:    "",
+				PackageManager:  "",
+				LicenseId:       "52c218ef-3444-49f9-9c8b-28dfa204cd74",
+				Eol:             "false",
+			},
+		},
+		{
+			name:   "automate path parses only required fields",
+			parser: &automateTailParser{},
+			ctx: &testContext{
+				params: map[string]string{
+					"channel":  "stable",
+					"product":  "automate",
+					"version":  "latest",
+					"platform": "linux",
+					"*":        "amd64/chef-automate_linux_amd64.zip",
+				},
+				query: map[string]string{
+					"license_id": "abc-123",
+					"eol":        "false",
+				},
+			},
+			want: &omnitruck.RequestParams{
+				Channel:         "stable",
+				Product:         "automate",
+				Version:         "latest",
+				Platform:        "linux",
+				PlatformVersion: "",
+				FileName:        "chef-automate_linux_amd64.zip",
+				Architecture:    "amd64",
+				PackageManager:  "",
+				LicenseId:       "abc-123",
+				Eol:             "false",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GetFilesRequestParamsWithStrategy(tt.ctx, tt.parser); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetFilesRequestParams() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateCommonRequiredFilesParams(t *testing.T) {
+	tests := []struct {
+		name    string
+		params  *omnitruck.RequestParams
+		wantErr string
+	}{
+		{
+			name: "common required fields are enforced",
+			params: &omnitruck.RequestParams{
+				Channel:  "stable",
+				Product:  "automate",
+				Platform: "linux",
+			},
+			wantErr: "Filename path param cannot be empty",
+		},
+		{
+			name: "valid infra params pass",
+			params: &omnitruck.RequestParams{
+				Channel:         "stable",
+				Product:         "chef-ice",
+				Platform:        "linux",
+				Architecture:    "x86_64",
+				PackageManager:  "rpm",
+				FileName:        "chef-ice-19.2.106-1.amzn2.x86_64.rpm",
+				PlatformVersion: "",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateCommonRequiredFilesParams(tt.params)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Equal(t, tt.wantErr, err.Error())
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestGetPackageUrl(t *testing.T) {
+	tests := []struct {
+		name     string
+		params   *omnitruck.RequestParams
+		fileName string
+		baseUrl  string
+		want     string
+	}{
+		{
+			name: "direct=true with license_id",
+			params: &omnitruck.RequestParams{
+				Channel:         "stable",
+				Product:         "chef",
+				Version:         "18.8.46",
+				Platform:        "debian",
+				PlatformVersion: "9",
+				Architecture:    "amd64",
+				PackageManager:  constants.DUMMY_PACKAGE_MANAGER, // Default products use dummy PM
+				Direct:          "true",
+				LicenseId:       "abc-123",
+			},
+			fileName: "chef_18.8.46-1_amd64.deb",
+			baseUrl:  "https://commercial-acceptance.downloads.chef.co",
+			want:     "https://commercial-acceptance.downloads.chef.co/files/stable/chef/18.8.46/debian/9/amd64/chef_18.8.46-1_amd64.deb?license_id=abc-123",
+		},
+		{
+			name: "direct=true without license_id always appends empty param",
+			params: &omnitruck.RequestParams{
+				Channel:         "stable",
+				Product:         "chef",
+				Version:         "18.8.46",
+				Platform:        "debian",
+				PlatformVersion: "9",
+				Architecture:    "amd64",
+				Direct:          "true",
+			},
+			fileName: "chef_18.8.46-1_amd64.deb",
+			baseUrl:  "https://commercial-acceptance.downloads.chef.co",
+			want:     "https://commercial-acceptance.downloads.chef.co/files/stable/chef/18.8.46/debian/9/amd64/chef_18.8.46-1_amd64.deb?license_id=",
+		},
+		{
+			name: "direct=false falls back to download URL",
+			params: &omnitruck.RequestParams{
+				Channel:      "stable",
+				Product:      "chef",
+				Version:      "18.2.7",
+				Platform:     "el",
+				Architecture: "x86_64",
+				Direct:       "false",
+				LicenseId:    "abc-123",
+			},
+			fileName: "chef-18.2.7-1.el6.x86_64.rpm",
+			baseUrl:  "https://packages.chef.io",
+			want:     "https://packages.chef.io/stable/chef/download?license_id=abc-123&m=x86_64&p=el&v=18.2.7",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetPackageUrl(tt.params, tt.baseUrl, tt.fileName)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/internal/services/services.go
+++ b/internal/services/services.go
@@ -231,10 +231,22 @@ func (svc *DownloadService) ProductMetadata(params *omnitruck.RequestParams) (da
 	}
 
 	data, request = productStrategy.GetMetadata(params)
+	if request.Ok {
+		fileName := params.FileName
+		if fileName == "" && params.Direct == "true" {
+			if resolvedFileName, err := productStrategy.GetFileName(params); err == nil {
+				fileName = resolvedFileName
+			}
+		}
 
-	// Remap the package url to our download URL
-	url := helpers.GetDownloadUrl(params, svc.locals["base_url"].(string))
-	data.Url = url
+		// For chef-360 (platform service), ignore direct=true and always use /download URL
+		if params.Product == constants.PLATFORM_SERVICE_PRODUCT {
+			params.Direct = ""
+		}
+
+		// Remap the package url to our endpoint URL (download by default, files when direct=true).
+		data.Url = helpers.GetPackageUrl(params, svc.locals["base_url"].(string), fileName)
+	}
 
 	if request.Ok {
 		return data, &clients.Request{
@@ -322,6 +334,45 @@ func (svc *DownloadService) GetFileName(params *omnitruck.RequestParams) (string
 		Code:    fiber.StatusOK,
 		Message: "File name retrieved successfully",
 	}
+}
+
+func (svc *DownloadService) ProductFilesDownload(c omnitruck.FiberContext) (string, io.ReadCloser, http.Header, string, int, error) {
+	svc.logCtx().Infof("Received product files download request for %s", c.Params("product"))
+
+	// Parse params using strategy-specific parser
+	productStrategy := strategy.SelectProductStrategy(c.Params("product"), c.Params("channel"), svc.ProductStrategyDeps())
+	var params *omnitruck.RequestParams
+	if parser, ok := productStrategy.(helpers.TailParser); ok {
+		params = helpers.GetFilesRequestParamsWithStrategy(c, parser)
+	} else {
+		params = helpers.GetFilesRequestParamsWithStrategy(c, &strategy.DefaultProductStrategy{})
+	}
+
+	// Validate common required fields
+	if err := helpers.ValidateCommonRequiredFilesParams(params); err != nil {
+		return "", nil, nil, err.Error(), fiber.StatusBadRequest, err
+	}
+
+	// Resolve partial version (e.g., "19.1" -> "19.1.172")
+	filtered, req := svc.getFilteredVersions(params)
+	if req != nil && !req.Ok {
+		return "", nil, nil, req.Message, req.Code, fiber.NewError(req.Code, req.Message)
+	}
+	if len(filtered) > 0 {
+		if err := helpers.ValidateOrSetVersion(params, filtered); err != nil {
+			return "", nil, nil, err.Error(), fiber.StatusBadRequest, err
+		}
+	}
+
+	// Validate strategy-specific fields
+	if validator, ok := productStrategy.(strategy.FilesParamsValidator); ok {
+		if err := validator.ValidateFilesParams(params); err != nil {
+			return "", nil, nil, err.Error(), fiber.StatusBadRequest, err
+		}
+	}
+
+	// Download using the product strategy
+	return productStrategy.Download(params)
 }
 
 func (svc *DownloadService) GetLinuxScript(params *omnitruck.RequestParams) (string, *clients.Request) {

--- a/internal/services/services_test.go
+++ b/internal/services/services_test.go
@@ -628,10 +628,14 @@ func TestDownloadService_ProductPackages(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
 			w.Write([]byte(`["16.0.0", "17.0.0"]`))
+		case strings.Contains(r.URL.Path, "/metadata"):
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(`{"sha1":"","sha256":"","url":"https://packages.chef.io/files/stable/chef/16.0.0/el/7/chef-16.0.0-1.el7.x86_64.rpm","version":"16.0.0"}`))
 		case strings.Contains(r.URL.Path, "/packages"):
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte(`{"chef":{"16.0.0":{"x86_64":{"url":"http://example.com/download","version":"16.0.0"}}}}`))
+			w.Write([]byte(`{"linux":{"20.04":{"x86_64":{"url":"http://example.com/download","version":"16.0.0"}}}}`))
 		default:
 			w.WriteHeader(http.StatusNotFound)
 			w.Write([]byte(`not found`))
@@ -663,6 +667,17 @@ func TestDownloadService_ProductPackages(t *testing.T) {
 				Product: "chef",
 				Channel: "stable",
 				Version: "16.0.0",
+			},
+			expectSuccess: true,
+			expectCode:    fiber.StatusOK,
+		},
+		{
+			name: "success returns product packages with direct url",
+			params: &omnitruck.RequestParams{
+				Product: "chef",
+				Channel: "stable",
+				Version: "16.0.0",
+				Direct:  "true",
 			},
 			expectSuccess: true,
 			expectCode:    fiber.StatusOK,
@@ -707,6 +722,9 @@ func TestDownloadService_ProductPackages(t *testing.T) {
 				assert.True(t, req.Ok, "expected ok true")
 				assert.Equal(t, tt.expectCode, req.Code)
 				assert.NotNil(t, data)
+				if tt.params.Direct == "true" {
+					assert.Equal(t, "http://example.com/files/stable/chef/16.0.0/linux/20.04/x86_64/chef-16.0.0-1.el7.x86_64.rpm?license_id=", data["linux"]["20.04"]["x86_64"].Url)
+				}
 			} else {
 				assert.False(t, req.Ok, "expected ok false")
 				assert.Equal(t, tt.expectCode, req.Code)
@@ -730,7 +748,7 @@ func TestDownloadService_ProductMetadata(t *testing.T) {
 			w.Write([]byte(`{
 				"sha1":"fake-sha1",
 				"sha256":"fake-sha256",
-				"url":"http://original-download",
+				"url":"https://packages.chef.io/files/stable/chef/16.0.0/el/7/chef-16.0.0-1.el7.x86_64.rpm",
 				"version":"16.0.0"
 			}`))
 		case strings.Contains(r.URL.Path, "invalid-product"):
@@ -777,6 +795,20 @@ func TestDownloadService_ProductMetadata(t *testing.T) {
 			expectCode:    fiber.StatusOK,
 		},
 		{
+			name: "success returns metadata with direct files url",
+			params: &omnitruck.RequestParams{
+				Product:         "chef",
+				Channel:         "stable",
+				Version:         "16.0.0",
+				Platform:        "ubuntu",
+				PlatformVersion: "20.04",
+				Architecture:    "x86_64",
+				Direct:          "true",
+			},
+			expectSuccess: true,
+			expectCode:    fiber.StatusOK,
+		},
+		{
 			name: "invalid product returns error",
 			params: &omnitruck.RequestParams{
 				Product:         "invalid-product",
@@ -813,6 +845,9 @@ func TestDownloadService_ProductMetadata(t *testing.T) {
 				assert.Equal(t, tt.expectCode, req.Code)
 				assert.NotEmpty(t, data.Url, "expected a remapped download URL")
 				expectedUrl := "http://example.com/stable/chef/download?m=x86_64&p=ubuntu&pv=20.04&v=16.0.0"
+				if tt.params.Direct == "true" {
+					expectedUrl = "http://example.com/files/stable/chef/16.0.0/ubuntu/20.04/x86_64/chef-16.0.0-1.el7.x86_64.rpm?license_id="
+				}
 				assert.Equal(t, expectedUrl, data.Url, "should remap to local download")
 			} else {
 				assert.False(t, req.Ok, "expected ProductMetadata to fail")

--- a/internal/strategy/automate_strategy.go
+++ b/internal/strategy/automate_strategy.go
@@ -15,8 +15,8 @@ import (
 // ProductDynamoStrategy implements ProductStrategy for Automate and Habitat products
 // Uses DynamoDB for most operations
 type ProductDynamoStrategy struct {
-	DynamoService omnitruck.IDynamoServices
-	Log           *log.Entry
+	DynamoService    omnitruck.IDynamoServices
+	Log              *log.Entry
 }
 
 func (s *ProductDynamoStrategy) GetLatestVersion(params *omnitruck.RequestParams) (omnitruck.ProductVersion, *clients.Request) {
@@ -83,14 +83,50 @@ func (s *ProductDynamoStrategy) GetFileName(params *omnitruck.RequestParams) (st
 	return fileName, err
 }
 
+// ValidateFilesParams for Automate/Habitat has no strategy-specific required fields.
+func (s *ProductDynamoStrategy) ValidateFilesParams(params *omnitruck.RequestParams) error {
+	// Validate filename matches what database expects
+	correctFileName, err := s.GetFileName(params)
+	if err != nil {
+		return err
+	}
+	if params.FileName != correctFileName {
+		return fmt.Errorf("invalid filename for the specified product parameters")
+	}
+
+	return nil
+}
+
 func (s *ProductDynamoStrategy) UpdatePackages(data *omnitruck.PackageList, params *omnitruck.RequestParams, baseUrl string) {
 	data.UpdatePackages(func(platform string, pv string, arch string, m omnitruck.PackageMetadata) omnitruck.PackageMetadata {
 		params.Version = m.Version
 		params.Platform = platform
 		params.Architecture = arch
 
-		m.Url = helpers.GetDownloadUrl(params, baseUrl)
+		fileName := ""
+		if params.Direct == "true" {
+			if resolvedFileName, err := s.GetFileName(params); err == nil {
+				fileName = resolvedFileName
+			}
+		}
+
+		m.Url = helpers.GetPackageUrl(params, baseUrl, fileName)
 
 		return m
 	})
+}
+
+// ParseTail parses the /files URL tail in Automate/Habitat format: {arch}/{fileName}
+// Expected format: arch/filename (exactly 2 segments)
+func (s *ProductDynamoStrategy) ParseTail(segments []string) helpers.FilesPathParams {
+	p := helpers.FilesPathParams{}
+
+	if len(segments) < 2 {
+		return p // Invalid format, will fail validation later
+	}
+
+	p.Architecture = segments[0]
+	p.FileName = segments[1]
+
+	return p
 }

--- a/internal/strategy/default_product_strategy.go
+++ b/internal/strategy/default_product_strategy.go
@@ -1,9 +1,11 @@
 package strategy
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/chef/omnitruck-service/clients"
 	"github.com/chef/omnitruck-service/clients/omnitruck"
@@ -78,6 +80,40 @@ func (s *DefaultProductStrategy) GetFileName(params *omnitruck.RequestParams) (s
 	return helpers.GetFileNameFromURL(data.Url), nil
 }
 
+// ValidateFilesParams enforces that PlatformVersion is provided for default products.
+func (s *DefaultProductStrategy) ValidateFilesParams(params *omnitruck.RequestParams) error {
+	if strings.TrimSpace(params.PlatformVersion) == "" {
+		return errors.New("Platform Version (pv) params cannot be empty")
+	}
+
+	// Validate filename matches what database expects
+	correctFileName, err := s.GetFileName(params)
+	if err != nil {
+		return err
+	}
+	if params.FileName != correctFileName {
+		return fmt.Errorf("invalid filename for the specified product parameters")
+	}
+
+	return nil
+}
+
+// ParseTail parses the /files URL tail in Default format: {platformVersion}/{arch}/{fileName}
+// Expected format: platformVersion/arch/filename (exactly 3 segments)
+func (s *DefaultProductStrategy) ParseTail(segments []string) helpers.FilesPathParams {
+	p := helpers.FilesPathParams{}
+
+	if len(segments) < 3 {
+		return p // Invalid format, will fail validation later
+	}
+
+	p.PlatformVersion = segments[0]
+	p.Architecture = segments[1]
+	p.FileName = segments[2]
+
+	return p
+}
+
 func (s *DefaultProductStrategy) UpdatePackages(data *omnitruck.PackageList, params *omnitruck.RequestParams, baseUrl string) {
 	data.UpdatePackages(func(platform string, pv string, arch string, m omnitruck.PackageMetadata) omnitruck.PackageMetadata {
 		params.Version = m.Version
@@ -85,7 +121,14 @@ func (s *DefaultProductStrategy) UpdatePackages(data *omnitruck.PackageList, par
 		params.PlatformVersion = pv
 		params.Architecture = arch
 
-		m.Url = helpers.GetDownloadUrl(params, baseUrl)
+		fileName := ""
+		if params.Direct == "true" {
+			if resolvedFileName, err := s.GetFileName(params); err == nil {
+				fileName = resolvedFileName
+			}
+		}
+
+		m.Url = helpers.GetPackageUrl(params, baseUrl, fileName)
 
 		return m
 	})

--- a/internal/strategy/infra_strategy.go
+++ b/internal/strategy/infra_strategy.go
@@ -19,9 +19,9 @@ import (
 )
 
 type InfraProductStrategy struct {
-	DynamoService omnitruck.IDynamoServices
-	AWSConfig     config.AWSConfig
-	Log           *log.Entry
+	DynamoService    omnitruck.IDynamoServices
+	AWSConfig        config.AWSConfig
+	Log              *log.Entry
 }
 
 func (s *InfraProductStrategy) normalizePackageManager(params *omnitruck.RequestParams) error {
@@ -175,6 +175,52 @@ func (s *InfraProductStrategy) GetFileName(params *omnitruck.RequestParams) (str
 	return fileName, err
 }
 
+// ValidateFilesParams ensures that PackageManager is set for infra products,
+// deriving from platform if not provided in URL.
+func (s *InfraProductStrategy) ValidateFilesParams(params *omnitruck.RequestParams) error {
+	// Normalize/derive package manager and platform
+	if err := s.normalizePackageManager(params); err != nil {
+		return fmt.Errorf(utils.PackageManagerParamsError)
+	}
+
+	s.Log.Infof("params after normalization: %+v", params)
+	// Validate filename matches what database expects (infra products only)
+	correctFileName, err := s.GetFileName(params)
+	if err != nil {
+		return err
+	}
+	if params.FileName != correctFileName {
+		s.Log.Info("Filename validation failed for /files endpoint")
+		return fmt.Errorf("invalid filename for the specified product parameters")
+	}
+
+	return nil
+}
+
+// ParseTail parses the /files URL tail in Infra format: {arch}/{pm}/{fileName}
+// Expected format: arch/pm/filename (exactly 3 segments)
+// PM is extracted from URL; normalizePackageManager will derive it if empty
+func (s *InfraProductStrategy) ParseTail(segments []string) helpers.FilesPathParams {
+	p := helpers.FilesPathParams{}
+
+	switch len(segments) {
+	case 0:
+		return p
+	case 1:
+		p.FileName = segments[0]
+	case 2:
+		p.Architecture = segments[0]
+		p.FileName = segments[1]
+	default:
+		// Expected: arch/pm/filename
+		p.Architecture = segments[0]
+		p.PackageManager = segments[1]
+		p.FileName = segments[2]
+	}
+
+	return p
+}
+
 func (s *InfraProductStrategy) UpdatePackages(data *omnitruck.PackageList, params *omnitruck.RequestParams, baseUrl string) {
 	data.UpdatePackages(func(platform string, arch string, packageManager string, m omnitruck.PackageMetadata) omnitruck.PackageMetadata {
 		params.Version = m.Version
@@ -182,7 +228,19 @@ func (s *InfraProductStrategy) UpdatePackages(data *omnitruck.PackageList, param
 		params.PackageManager = packageManager
 		params.Architecture = arch
 
-		m.Url = helpers.GetDownloadUrl(params, baseUrl)
+		fileName := ""
+		if params.Direct == "true" {
+			if resolvedFileName, err := s.GetFileName(params); err == nil {
+				fileName = resolvedFileName
+			}
+		}
+
+		if strings.EqualFold(params.Direct, "true") && fileName != "" {
+			// Infra products include the package manager segment in the /files URL path.
+			m.Url = helpers.GetFilesUrl(params, baseUrl, fileName, packageManager)
+		} else {
+			m.Url = helpers.GetDownloadUrl(params, baseUrl)
+		}
 		return m
 	})
 }

--- a/internal/strategy/platform_service_strategy.go
+++ b/internal/strategy/platform_service_strategy.go
@@ -144,6 +144,11 @@ func (s *PlatformServiceStrategy) GetFileName(params *omnitruck.RequestParams) (
 	return s.PlatformService.PlatformFilename(params, int(s.Mode))
 }
 
+// ParseTail is a null implementation — PlatformServiceStrategy does not use the /files path endpoint.
+func (s *PlatformServiceStrategy) ParseTail(_ []string) helpers.FilesPathParams {
+	return helpers.FilesPathParams{}
+}
+
 func (s *PlatformServiceStrategy) UpdatePackages(data *omnitruck.PackageList, params *omnitruck.RequestParams, baseUrl string) {
 	data.UpdatePackages(func(platform string, pv string, arch string, m omnitruck.PackageMetadata) omnitruck.PackageMetadata {
 		params.Version = m.Version

--- a/internal/strategy/product_strategy.go
+++ b/internal/strategy/product_strategy.go
@@ -24,6 +24,12 @@ type ProductStrategy interface {
 	UpdatePackages(data *omnitruck.PackageList, params *omnitruck.RequestParams, baseUrl string)
 }
 
+// FilesParamsValidator is implemented by each ProductStrategy to validate
+// the strategy-specific required parameters for the /files endpoint.
+type FilesParamsValidator interface {
+	ValidateFilesParams(params *omnitruck.RequestParams) error
+}
+
 type ProductStrategyDeps struct {
 	DynamoService     omnitruck.IDynamoServices
 	PlatformService   omnitruck.IPlatformServices
@@ -55,7 +61,10 @@ func SelectProductStrategy(product string, channel string, deps *ProductStrategy
 		}
 	case constants.CHEF_INFRA_CLIENT_ENTERPRISE_PRODUCT, constants.MIGRATE_ICE, constants.CHEF_INSPEC_ENTERPRISE_PRODUCT, constants.CHEF_WORKSTATION_ENTERPRISE:
 		if !deps.Config.SupportInfra19 {
-			return &DefaultProductStrategy{OmnitruckService: deps.OmnitruckService}
+			return &DefaultProductStrategy{
+				OmnitruckService: deps.OmnitruckService,
+				Log:              deps.Log,
+			}
 		}
 		if channel == constants.CURRENT_CHANNEL {
 			deps.DynamoService.SetDbInfo(deps.Config.PackageDetailsCurrentTable, reflect.TypeOf(models.PackageDetails{}))
@@ -63,9 +72,9 @@ func SelectProductStrategy(product string, channel string, deps *ProductStrategy
 			deps.DynamoService.SetDbInfo(deps.Config.PackageDetailsStableTable, reflect.TypeOf(models.PackageDetails{}))
 		}
 		return &InfraProductStrategy{
-			DynamoService: deps.DynamoService,
-			Log:           deps.Log,
-			AWSConfig:     deps.Config.AWSConfig,
+			DynamoService:    deps.DynamoService,
+			Log:              deps.Log,
+			AWSConfig:        deps.Config.AWSConfig,
 		}
 	default:
 		return &DefaultProductStrategy{


### PR DESCRIPTION
<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->
This pull request introduces a new `/files` download endpoint, enabling direct file downloads using path parameters and improving how download URLs are generated and validated. It also adds support for the `direct` URL parameter to allow clients to request direct download links, and includes comprehensive tests for the new behaviors. Several internal helpers and the Omnitruck client interface are extended to support these features.

**New `/files` endpoint and direct download support:**

* Added the `ProductFilesDownloadHandler` to handle `/files/:channel/:product/:version/:platform/*` routes, parsing path segments for platform version, architecture, package manager, and filename, with robust validation and error handling. [[1]](diffhunk://#diff-7f438e74079bd3146168e3fbe81ec49bc4f5981bfad8fdca550f5a136a64687bR57) [[2]](diffhunk://#diff-d44aedc84f5e5cffdc3539475fcfeb7e22d96e5c0e5b591b964dc3366c86d0d4R347-R391)
* Introduced the `direct` query parameter in `RequestParams`, allowing clients to receive direct file download URLs in metadata and packages endpoints. [[1]](diffhunk://#diff-36f3db9713f64cb9e056e5f6fb87dad8445a14aa7419db614641f9e5f7bfdcbfR55-R56) [[2]](diffhunk://#diff-4ebb32a36e9c4d54f3199a045afccbd13e4a6626d9eeb56b35ef90f73ec062f1R124-R167)

**Helpers and URL construction:**

* Added `FilesPathParams`, `TailParser`, and related helpers for parsing and validating `/files` endpoint paths, and created `filesURLBuilder` and `GetFilesUrl` to construct direct download URLs. [[1]](diffhunk://#diff-4ebb32a36e9c4d54f3199a045afccbd13e4a6626d9eeb56b35ef90f73ec062f1R16-R29) [[2]](diffhunk://#diff-4ebb32a36e9c4d54f3199a045afccbd13e4a6626d9eeb56b35ef90f73ec062f1R48-R111) [[3]](diffhunk://#diff-4ebb32a36e9c4d54f3199a045afccbd13e4a6626d9eeb56b35ef90f73ec062f1R124-R167)
* Updated `GetPackageUrl` to automatically route to `/files` when `direct=true` is set and a filename is present.

**Omnitruck client and mock updates:**

* Extended the `IOmnitruck` interface and `MockOmnitruck` to support an `Architectures` method for querying available architectures. [[1]](diffhunk://#diff-36f3db9713f64cb9e056e5f6fb87dad8445a14aa7419db614641f9e5f7bfdcbfR78) [[2]](diffhunk://#diff-3e5de37c4cd70940744628f11fa611aa750b1501fcd0705c82bc8c434a80b894R11) [[3]](diffhunk://#diff-3e5de37c4cd70940744628f11fa611aa750b1501fcd0705c82bc8c434a80b894R44-R49)

**Testing:**

* Added comprehensive tests for the `/files` endpoint, including path parsing, validation, and direct URL generation, as well as tests for the `direct` parameter in metadata and packages handlers.

**Miscellaneous:**

* Minor import and whitespace cleanups for clarity and dependency management. [[1]](diffhunk://#diff-3e5de37c4cd70940744628f11fa611aa750b1501fcd0705c82bc8c434a80b894R2) [[2]](diffhunk://#diff-44f7799f1d99bda9f91556f2a4bab18af27b4e778e5a1ff6898f58c6d46192e9R6-R14)

These changes provide a more flexible and robust download mechanism, making it easier for clients to obtain direct file links and improving the maintainability of download-related code.
## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] If `Gemfile.lock` has changed, I have used `--conservative` to do it and included the full output in the Description above.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).


Demo: https://progresssoftware.sharepoint.com/:v:/s/ChefCoreC/IQCl4tfJqs66TbYvt6ovqtipAWeafb8gDY2hHGu6Irw7n1k?e=fslTqc

JIRA: https://progresssoftware.atlassian.net/browse/CHEF-33117