### PR TITLE
Accept common enterprise OS variants as platform aliases

### DIFF
--- a/clients/omnitruck/package_manager_mapping.go
+++ b/clients/omnitruck/package_manager_mapping.go
@@ -2,54 +2,164 @@ package omnitruck
 
 import "strings"
 
+// platformToPackageManager maps a caller-supplied platform to the package format
+// we publish for it.
+//
+// Entries are grouped by platform family. Within a family every alias resolves to
+// the same package format, because the family is what determines the artifact.
+//
+// Aliases exist because callers legitimately report different names for the same
+// platform:
+//
+//   - Ohai's `node['platform']` (what Chef Infra Client reports).
+//   - The raw `ID=` field from /etc/os-release. Chef's own install.sh falls back to
+//     `platform=$ID` for any distro without an older release file, and Ohai
+//     normalizes several of these (e.g. `ol` -> `oracle`, `opensuse-leap` ->
+//     `opensuseleap`, `rhel` -> `redhat`).
+//   - LSB `DISTRIB_ID`, which install.sh uses when /etc/lsb-release is present.
+//
+// install.sh is explicit that this normalization belongs here rather than in the
+// client: "remapping platform and mangling platform version numbers is now the
+// complete responsibility of the server-side endpoints".
 var platformToPackageManager = map[string]string{
-	"aix":           "bff",
-	"amazon":        "rpm",
-	"centos":        "rpm",
-	"darwin":        "dmg",
-	"debian":        "deb",
-	"el":            "rpm",
-	"fedora":        "rpm",
-	"freebsd":       "sh",
-	"ios_xr":        "rpm",
+	// Enterprise Linux (RHEL and rebuilds/derivatives)
+	"almalinux":            "rpm",
+	"alibabalinux":         "rpm",
+	"alinux":               "rpm", // os-release ID for Alibaba Cloud Linux
+	"bigip":                "rpm",
+	"centos":               "rpm",
+	"clearos":              "rpm",
+	"cloudlinux":           "rpm",
+	"el":                   "rpm",
+	"enterpriseenterprise": "rpm", // Oracle Linux LSB distributor ID
+	"ibm_powerkvm":         "rpm",
+	"nexus_centos":         "rpm",
+	"ol":                   "rpm", // os-release ID for Oracle Linux
+	"oracle":               "rpm",
+	"parallels":            "rpm",
+	"redhat":               "rpm",
+	"rhel":                 "rpm", // os-release ID for RHEL
+	"rocky":                "rpm",
+	"sangoma":              "rpm",
+	"scientific":           "rpm",
+	"virtuozzo":            "rpm",
+	"xcp-ng":               "rpm",
+	"xenenterprise":        "rpm", // os-release ID for XenServer 7.5+
+	"xenserver":            "rpm",
+
+	// Fedora and Fedora-derived
+	"arista_eos": "rpm",
+	"fedora":     "rpm",
+
+	// Amazon Linux
+	"amazon": "rpm",
+	"amzn":   "rpm", // os-release ID for Amazon Linux
+
+	// SUSE
+	"opensuse":      "rpm",
+	"opensuse-leap": "rpm", // os-release ID for openSUSE Leap 15+
+	"opensuseleap":  "rpm",
+	"sled":          "rpm",
+	"sles":          "rpm",
+	"sles_sap":      "rpm", // os-release ID for SLES for SAP
+	"suse":          "rpm",
+
+	// Debian and Debian-derived
+	"cumulus":          "deb",
+	"cumulus-linux":    "deb", // os-release ID for Cumulus Linux
+	"cumulus_linux":    "deb", // LSB DISTRIB_ID for Cumulus Linux
+	"cumulus_networks": "deb", // LSB DISTRIB_ID for Cumulus Networks
+	"debian":           "deb",
+	"kali":             "deb",
+	"linuxmint":        "deb",
+	"pop":              "deb",
+	"raspbian":         "deb",
+	"ubuntu":           "deb",
+
+	// Wind River Linux (Cisco network operating systems)
+	"ios_xr": "rpm",
+	"nexus":  "rpm",
+
+	// Generic Linux
 	"linux":         "rpm",
 	"linux-kernel2": "rpm",
-	"linuxmint":     "deb",
-	"mac_os_x":      "dmg",
-	"nexus":         "rpm",
-	"opensuseleap":  "rpm",
-	"redhat":        "rpm",
-	"rocky":         "rpm",
-	"sles":          "rpm",
-	"solaris2":      "p5p",
-	"suse":          "rpm",
-	"ubuntu":        "deb",
-	"windows":       "msi",
+
+	// macOS
+	"darwin":   "dmg",
+	"mac_os_x": "dmg",
+	"macos":    "dmg",
+
+	// Windows
+	"windows": "msi",
+
+	// Other UNIX
+	"aix":      "bff",
+	"freebsd":  "sh",
+	"solaris":  "p5p",
+	"solaris2": "p5p",
 }
 
-// platformToDbPlatform maps user-provided platforms to database platform keys
+// platformToDbPlatform maps user-provided platforms to database platform keys.
+//
+// Every platform in platformToPackageManager must also appear here, otherwise an
+// otherwise-valid alias resolves a package manager but then fails the lookup with
+// "Product information not found" because the un-normalized name reaches the
+// database. TestEveryPackageManagerPlatformHasDbMapping enforces this.
 var platformToDbPlatform = map[string]string{
 	// Linux variants all map to "linux" in database
-	"amazon":        "linux",
-	"centos":        "linux",
-	"debian":        "linux",
-	"el":            "linux",
-	"fedora":        "linux",
-	"ios_xr":        "linux",
-	"linux":         "linux",
-	"linux-kernel2": "linux",
-	"linuxmint":     "linux",
-	"nexus":         "linux",
-	"opensuseleap":  "linux",
-	"redhat":        "linux",
-	"rocky":         "linux",
-	"sles":          "linux",
-	"suse":          "linux",
-	"ubuntu":        "linux",
+	"almalinux":            "linux",
+	"alibabalinux":         "linux",
+	"alinux":               "linux",
+	"amazon":               "linux",
+	"amzn":                 "linux",
+	"arista_eos":           "linux",
+	"bigip":                "linux",
+	"centos":               "linux",
+	"clearos":              "linux",
+	"cloudlinux":           "linux",
+	"cumulus":              "linux",
+	"cumulus-linux":        "linux",
+	"cumulus_linux":        "linux",
+	"cumulus_networks":     "linux",
+	"debian":               "linux",
+	"el":                   "linux",
+	"enterpriseenterprise": "linux",
+	"fedora":               "linux",
+	"ibm_powerkvm":         "linux",
+	"ios_xr":               "linux",
+	"kali":                 "linux",
+	"linux":                "linux",
+	"linux-kernel2":        "linux",
+	"linuxmint":            "linux",
+	"nexus":                "linux",
+	"nexus_centos":         "linux",
+	"ol":                   "linux",
+	"opensuse":             "linux",
+	"opensuse-leap":        "linux",
+	"opensuseleap":         "linux",
+	"oracle":               "linux",
+	"parallels":            "linux",
+	"pop":                  "linux",
+	"raspbian":             "linux",
+	"redhat":               "linux",
+	"rhel":                 "linux",
+	"rocky":                "linux",
+	"sangoma":              "linux",
+	"scientific":           "linux",
+	"sled":                 "linux",
+	"sles":                 "linux",
+	"sles_sap":             "linux",
+	"suse":                 "linux",
+	"ubuntu":               "linux",
+	"virtuozzo":            "linux",
+	"xcp-ng":               "linux",
+	"xenenterprise":        "linux",
+	"xenserver":            "linux",
 
 	// Darwin/macOS variants
 	"darwin":   "darwin",
 	"mac_os_x": "darwin",
+	"macos":    "darwin",
 
 	// Windows variants
 	"windows": "windows",
@@ -57,6 +167,7 @@ var platformToDbPlatform = map[string]string{
 	// Others remain as-is for now (may not exist in DB)
 	"aix":      "aix",
 	"freebsd":  "freebsd",
+	"solaris":  "solaris2",
 	"solaris2": "solaris2",
 }
 

--- a/clients/omnitruck/package_manager_mapping_test.go
+++ b/clients/omnitruck/package_manager_mapping_test.go
@@ -8,30 +8,86 @@ func TestDerivePackageManager(t *testing.T) {
 		platform string
 		want     string
 	}{
-		{name: "aix", platform: "aix", want: "bff"},
-		{name: "amazon", platform: "amazon", want: "rpm"},
+		// Enterprise Linux
+		{name: "almalinux", platform: "almalinux", want: "rpm"},
+		{name: "alibabalinux", platform: "alibabalinux", want: "rpm"},
+		{name: "alinux", platform: "alinux", want: "rpm"},
+		{name: "bigip", platform: "bigip", want: "rpm"},
 		{name: "centos", platform: "centos", want: "rpm"},
-		{name: "darwin", platform: "darwin", want: "dmg"},
-		{name: "debian", platform: "debian", want: "deb"},
+		{name: "clearos", platform: "clearos", want: "rpm"},
+		{name: "cloudlinux", platform: "cloudlinux", want: "rpm"},
 		{name: "el", platform: "el", want: "rpm"},
+		{name: "enterpriseenterprise", platform: "enterpriseenterprise", want: "rpm"},
+		{name: "ibm_powerkvm", platform: "ibm_powerkvm", want: "rpm"},
+		{name: "nexus_centos", platform: "nexus_centos", want: "rpm"},
+		{name: "ol", platform: "ol", want: "rpm"},
+		{name: "oracle", platform: "oracle", want: "rpm"},
+		{name: "parallels", platform: "parallels", want: "rpm"},
+		{name: "redhat", platform: "redhat", want: "rpm"},
+		{name: "rhel", platform: "rhel", want: "rpm"},
+		{name: "rocky", platform: "rocky", want: "rpm"},
+		{name: "sangoma", platform: "sangoma", want: "rpm"},
+		{name: "scientific", platform: "scientific", want: "rpm"},
+		{name: "virtuozzo", platform: "virtuozzo", want: "rpm"},
+		{name: "xcp-ng", platform: "xcp-ng", want: "rpm"},
+		{name: "xenenterprise", platform: "xenenterprise", want: "rpm"},
+		{name: "xenserver", platform: "xenserver", want: "rpm"},
+
+		// Fedora and Fedora-derived
+		{name: "arista_eos", platform: "arista_eos", want: "rpm"},
 		{name: "fedora", platform: "fedora", want: "rpm"},
-		{name: "freebsd", platform: "freebsd", want: "sh"},
+
+		// Amazon Linux
+		{name: "amazon", platform: "amazon", want: "rpm"},
+		{name: "amzn", platform: "amzn", want: "rpm"},
+
+		// SUSE
+		{name: "opensuse", platform: "opensuse", want: "rpm"},
+		{name: "opensuse-leap", platform: "opensuse-leap", want: "rpm"},
+		{name: "opensuseleap", platform: "opensuseleap", want: "rpm"},
+		{name: "sled", platform: "sled", want: "rpm"},
+		{name: "sles", platform: "sles", want: "rpm"},
+		{name: "sles_sap", platform: "sles_sap", want: "rpm"},
+		{name: "suse", platform: "suse", want: "rpm"},
+
+		// Debian and Debian-derived
+		{name: "cumulus", platform: "cumulus", want: "deb"},
+		{name: "cumulus-linux", platform: "cumulus-linux", want: "deb"},
+		{name: "cumulus_linux", platform: "cumulus_linux", want: "deb"},
+		{name: "cumulus_networks", platform: "cumulus_networks", want: "deb"},
+		{name: "debian", platform: "debian", want: "deb"},
+		{name: "kali", platform: "kali", want: "deb"},
+		{name: "linuxmint", platform: "linuxmint", want: "deb"},
+		{name: "pop", platform: "pop", want: "deb"},
+		{name: "raspbian", platform: "raspbian", want: "deb"},
+		{name: "ubuntu", platform: "ubuntu", want: "deb"},
+
+		// Wind River Linux
 		{name: "ios_xr", platform: "ios_xr", want: "rpm"},
+		{name: "nexus", platform: "nexus", want: "rpm"},
+
+		// Generic Linux
 		{name: "linux", platform: "linux", want: "rpm"},
 		{name: "linux-kernel2", platform: "linux-kernel2", want: "rpm"},
-		{name: "linuxmint", platform: "linuxmint", want: "deb"},
+
+		// macOS
+		{name: "darwin", platform: "darwin", want: "dmg"},
 		{name: "mac_os_x", platform: "mac_os_x", want: "dmg"},
-		{name: "nexus", platform: "nexus", want: "rpm"},
-		{name: "opensuseleap", platform: "opensuseleap", want: "rpm"},
-		{name: "redhat", platform: "redhat", want: "rpm"},
-		{name: "rocky", platform: "rocky", want: "rpm"},
-		{name: "sles", platform: "sles", want: "rpm"},
-		{name: "solaris2", platform: "solaris2", want: "p5p"},
-		{name: "suse", platform: "suse", want: "rpm"},
-		{name: "ubuntu", platform: "ubuntu", want: "deb"},
+		{name: "macos", platform: "macos", want: "dmg"},
+
+		// Windows
 		{name: "windows", platform: "windows", want: "msi"},
+
+		// Other UNIX
+		{name: "aix", platform: "aix", want: "bff"},
+		{name: "freebsd", platform: "freebsd", want: "sh"},
+		{name: "solaris", platform: "solaris", want: "p5p"},
+		{name: "solaris2", platform: "solaris2", want: "p5p"},
+
+		// Input normalization
 		{name: "platform with spaces", platform: "  windows ", want: "msi"},
 		{name: "platform with mixed case", platform: "Ubuntu", want: "deb"},
+		{name: "mixed case alias", platform: "AlmaLinux", want: "rpm"},
 		{name: "unknown", platform: "unknown", want: ""},
 	}
 
@@ -50,30 +106,86 @@ func TestNormalizePlatformForDatabase(t *testing.T) {
 		platform string
 		want     string
 	}{
-		{name: "amazon", platform: "amazon", want: "linux"},
+		// Enterprise Linux
+		{name: "almalinux", platform: "almalinux", want: "linux"},
+		{name: "alibabalinux", platform: "alibabalinux", want: "linux"},
+		{name: "alinux", platform: "alinux", want: "linux"},
+		{name: "bigip", platform: "bigip", want: "linux"},
 		{name: "centos", platform: "centos", want: "linux"},
-		{name: "debian", platform: "debian", want: "linux"},
+		{name: "clearos", platform: "clearos", want: "linux"},
+		{name: "cloudlinux", platform: "cloudlinux", want: "linux"},
 		{name: "el", platform: "el", want: "linux"},
+		{name: "enterpriseenterprise", platform: "enterpriseenterprise", want: "linux"},
+		{name: "ibm_powerkvm", platform: "ibm_powerkvm", want: "linux"},
+		{name: "nexus_centos", platform: "nexus_centos", want: "linux"},
+		{name: "ol", platform: "ol", want: "linux"},
+		{name: "oracle", platform: "oracle", want: "linux"},
+		{name: "parallels", platform: "parallels", want: "linux"},
+		{name: "redhat", platform: "redhat", want: "linux"},
+		{name: "rhel", platform: "rhel", want: "linux"},
+		{name: "rocky", platform: "rocky", want: "linux"},
+		{name: "sangoma", platform: "sangoma", want: "linux"},
+		{name: "scientific", platform: "scientific", want: "linux"},
+		{name: "virtuozzo", platform: "virtuozzo", want: "linux"},
+		{name: "xcp-ng", platform: "xcp-ng", want: "linux"},
+		{name: "xenenterprise", platform: "xenenterprise", want: "linux"},
+		{name: "xenserver", platform: "xenserver", want: "linux"},
+
+		// Fedora and Fedora-derived
+		{name: "arista_eos", platform: "arista_eos", want: "linux"},
 		{name: "fedora", platform: "fedora", want: "linux"},
+
+		// Amazon Linux
+		{name: "amazon", platform: "amazon", want: "linux"},
+		{name: "amzn", platform: "amzn", want: "linux"},
+
+		// SUSE
+		{name: "opensuse", platform: "opensuse", want: "linux"},
+		{name: "opensuse-leap", platform: "opensuse-leap", want: "linux"},
+		{name: "opensuseleap", platform: "opensuseleap", want: "linux"},
+		{name: "sled", platform: "sled", want: "linux"},
+		{name: "sles", platform: "sles", want: "linux"},
+		{name: "sles_sap", platform: "sles_sap", want: "linux"},
+		{name: "suse", platform: "suse", want: "linux"},
+
+		// Debian and Debian-derived
+		{name: "cumulus", platform: "cumulus", want: "linux"},
+		{name: "cumulus-linux", platform: "cumulus-linux", want: "linux"},
+		{name: "cumulus_linux", platform: "cumulus_linux", want: "linux"},
+		{name: "cumulus_networks", platform: "cumulus_networks", want: "linux"},
+		{name: "debian", platform: "debian", want: "linux"},
+		{name: "kali", platform: "kali", want: "linux"},
+		{name: "linuxmint", platform: "linuxmint", want: "linux"},
+		{name: "pop", platform: "pop", want: "linux"},
+		{name: "raspbian", platform: "raspbian", want: "linux"},
+		{name: "ubuntu", platform: "ubuntu", want: "linux"},
+
+		// Wind River Linux
 		{name: "ios_xr", platform: "ios_xr", want: "linux"},
+		{name: "nexus", platform: "nexus", want: "linux"},
+
+		// Generic Linux
 		{name: "linux", platform: "linux", want: "linux"},
 		{name: "linux-kernel2", platform: "linux-kernel2", want: "linux"},
-		{name: "linuxmint", platform: "linuxmint", want: "linux"},
-		{name: "nexus", platform: "nexus", want: "linux"},
-		{name: "opensuseleap", platform: "opensuseleap", want: "linux"},
-		{name: "redhat", platform: "redhat", want: "linux"},
-		{name: "rocky", platform: "rocky", want: "linux"},
-		{name: "sles", platform: "sles", want: "linux"},
-		{name: "suse", platform: "suse", want: "linux"},
-		{name: "ubuntu", platform: "ubuntu", want: "linux"},
+
+		// macOS
 		{name: "darwin", platform: "darwin", want: "darwin"},
 		{name: "mac_os_x", platform: "mac_os_x", want: "darwin"},
+		{name: "macos", platform: "macos", want: "darwin"},
+
+		// Windows
 		{name: "windows", platform: "windows", want: "windows"},
+
+		// Other UNIX
 		{name: "aix", platform: "aix", want: "aix"},
 		{name: "freebsd", platform: "freebsd", want: "freebsd"},
+		{name: "solaris", platform: "solaris", want: "solaris2"},
 		{name: "solaris2", platform: "solaris2", want: "solaris2"},
+
+		// Input normalization
 		{name: "platform with spaces", platform: "  Ubuntu ", want: "linux"},
 		{name: "platform with mixed case", platform: "Ubuntu", want: "linux"},
+		{name: "mixed case alias", platform: "AlmaLinux", want: "linux"},
 		{name: "unknown platform returned as-is", platform: "unknown", want: "unknown"},
 	}
 
@@ -81,6 +193,62 @@ func TestNormalizePlatformForDatabase(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := NormalizePlatformForDatabase(tt.platform); got != tt.want {
 				t.Errorf("NormalizePlatformForDatabase() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// A platform that derives a package manager but has no database mapping fails
+// later, and less obviously, with "Product information not found" -- the
+// un-normalized platform name reaches the database lookup. Keep the two maps in
+// sync so a new alias is either fully supported or not accepted at all.
+func TestEveryPackageManagerPlatformHasDbMapping(t *testing.T) {
+	for platform := range platformToPackageManager {
+		if _, ok := platformToDbPlatform[platform]; !ok {
+			t.Errorf("platform %q is in platformToPackageManager but missing from platformToDbPlatform", platform)
+		}
+	}
+}
+
+func TestEveryDbPlatformDerivesAPackageManager(t *testing.T) {
+	for platform := range platformToDbPlatform {
+		if DerivePackageManager(platform) == "" {
+			t.Errorf("platform %q is in platformToDbPlatform but missing from platformToPackageManager", platform)
+		}
+	}
+}
+
+// Aliases for the same underlying platform must agree on both the package format
+// and the database key, otherwise the artifact a caller receives depends on which
+// spelling their platform detection happened to report.
+func TestPlatformAliasesAgree(t *testing.T) {
+	aliasGroups := map[string][]string{
+		"oracle linux":  {"oracle", "ol", "enterpriseenterprise"},
+		"rhel":          {"redhat", "rhel"},
+		"xenserver":     {"xenserver", "xenenterprise"},
+		"alibaba linux": {"alibabalinux", "alinux"},
+		"amazon linux":  {"amazon", "amzn"},
+		"opensuse leap": {"opensuseleap", "opensuse-leap"},
+		"cumulus linux": {"cumulus", "cumulus-linux", "cumulus_linux", "cumulus_networks"},
+		"macos":         {"mac_os_x", "darwin", "macos"},
+		"solaris":       {"solaris", "solaris2"},
+		"sles":          {"sles", "sles_sap"},
+	}
+
+	for name, aliases := range aliasGroups {
+		t.Run(name, func(t *testing.T) {
+			wantPM := DerivePackageManager(aliases[0])
+			wantDB := NormalizePlatformForDatabase(aliases[0])
+			if wantPM == "" {
+				t.Fatalf("alias group %q: reference platform %q derives no package manager", name, aliases[0])
+			}
+			for _, alias := range aliases[1:] {
+				if got := DerivePackageManager(alias); got != wantPM {
+					t.Errorf("DerivePackageManager(%q) = %q, want %q (same as %q)", alias, got, wantPM, aliases[0])
+				}
+				if got := NormalizePlatformForDatabase(alias); got != wantDB {
+					t.Errorf("NormalizePlatformForDatabase(%q) = %q, want %q (same as %q)", alias, got, wantDB, aliases[0])
+				}
 			}
 		})
 	}

--- a/docs/DownloadAPI-Commercial.md
+++ b/docs/DownloadAPI-Commercial.md
@@ -19,6 +19,8 @@ Chef recommends using the stable channel when installing any of these products o
   
 `p` is the platform. Possible values: debian, el (for RHEL derivatives), freebsd, mac_os_x, solaris2, sles, suse, ubuntu or windows.
 
+The platform is also accepted as the name Ohai reports in `node['platform']` (for example `almalinux`, `oracle`, `rocky`, `raspbian`) or as the raw `ID` field from `/etc/os-release` (for example `rhel`, `ol`, `amzn`, `opensuse-leap`). These are normalized server-side to the platform family that the artifact is published for, so callers do not need to remap the platform themselves.
+
 `pv` is the platform version. Possible values depend on the platform. For example, Ubuntu: 18.04, or 20.04 or for macOS: 10.15 or 11.
 
 `m` is the machine architecture for the machine on which the product will be installed. Possible values depend on the platform. For example, for Ubuntu  or Debian: i386 or x86_64 or for macOS: x86_64.


### PR DESCRIPTION
## Problem

When `pm` is omitted, `normalizePackageManager` derives the package format from `p` and fails the request if the platform isn't a key in `platformToPackageManager`:

```
HTTP 400 {"message":"Unable to derive package manager for platform 'almalinux'"}
```

The map held a fairly narrow set of names, so a number of platforms that Chef Infra Client and `install.sh` genuinely report were rejected. Verified against `chefdownload-commercial.chef.io` — every one of these returns 400 today:

| | | | |
|---|---|---|---|
| `almalinux` | `oracle` | `ol` | `rhel` |
| `scientific` | `cloudlinux` | `virtuozzo` | `xenserver` |
| `arista_eos` | `cumulus_linux` | `cumulus_networks` | `raspbian` |
| `kali` | `amzn` | `macos` | `opensuse-leap` |
| `sles_sap` | | | |

`opensuse-leap` is the clearest case. It's the raw `/etc/os-release` `ID` on openSUSE Leap 15+, which is exactly what `install.sh` sends on that platform, but the map only had the unhyphenated `opensuseleap`.

`almalinux` and `oracle` are the highest-impact ones — both are mainstream CentOS replacements in enterprise fleets, and both are what Ohai reports in `node['platform']`.

## Why this layer

`install.sh` states that this normalization is the server's job, not the client's:

```sh
# NOTE: platform mangling in the install.sh is DEPRECATED
#
# - install.sh should be true to ohai and should not remap
#   platform or platform versions.
#
# - remapping platform and mangling platform version numbers is
#   now the complete responsibility of the server-side endpoints
```

and earlier in the same file:

```sh
# ALSO NOTE: Do not mangle platform or platform_version here.  It is less error
# prone and more future-proof to do that in the server, and then all omnitruck clients
# will 'inherit' the changes (install.sh is not the only client of the omnitruck
# endpoint out there).
```

So clients are doing what they're told, and the names land here un-remapped.

## What changed

Aliases are drawn from three sources that callers actually report, rather than being invented:

1. **Ohai's `node['platform']`** — per `platform_family_from_platform` in `ohai/plugins/linux/platform.rb`
2. **The raw `ID` field of `/etc/os-release`** — `install.sh` falls back to `platform=$ID`; Ohai normalizes several of these (`ol` → `oracle`, `rhel` → `redhat`, `opensuse-leap` → `opensuseleap`)
3. **LSB `DISTRIB_ID`** — used by `install.sh` when `/etc/lsb-release` exists (this is where `cumulus_linux` / `cumulus_networks` come from)

Scoped to families we publish packages for, so every alias resolves to an artifact that actually exists. Platforms we ship nothing for (gentoo, arch, alpine, slackware, …) are deliberately left out and still 400.

The maps are now grouped by family with comments, since the rationale for an individual alias isn't obvious from the name alone.

### Both maps, not just one

Aliases are added to **`platformToDbPlatform` as well as `platformToPackageManager`**. Adding to only the latter is a silent trap: the request gets past package manager derivation, then the un-normalized name reaches the database lookup and fails with the much less obvious `"Product information not found"`. Confirmed live with `p=almalinux&pm=rpm`, which fails that way today.

`TestEveryPackageManagerPlatformHasDbMapping` and `TestEveryDbPlatformDerivesAPackageManager` turn that desync into a test failure instead of a runtime surprise. I verified both actually catch it by deleting an entry and watching them fail, rather than assuming.

`TestPlatformAliasesAgree` asserts that aliases for one platform resolve to the same package format *and* the same database key — otherwise which artifact a caller gets would depend on which spelling their platform detection happened to produce.

## Compatibility

No behavior change for anything that already worked. Every pre-existing entry keeps its exact value, and unknown platforms are still rejected. This is purely additive: requests that returned 400 may now return 200.

## Testing

- `make check` — clean
- `go test -race -vet=off ./...` — `clients/omnitruck` passes, including the new tests

One note: `internal/api/handler` fails with a nil pointer dereference in `MockIDbOperations.GetVersionLatest` via the automate `ProductFilesDownload` path. **This is pre-existing on `main` and unrelated to this change** — I confirmed by running that package on a pristine checkout (`git stash`), where it fails identically. Happy to open a separate issue for it.

## Docs

Updated `docs/DownloadAPI-Commercial.md` to mention that Ohai platform names and `/etc/os-release` IDs are accepted and normalized server-side, so callers know they don't need to remap themselves.
